### PR TITLE
Improve child selector UI and default selection in parent pages

### DIFF
--- a/src/pages/Parent.tsx
+++ b/src/pages/Parent.tsx
@@ -1,7 +1,7 @@
 import { useParentChildren } from "@/hooks/useParentChildren.ts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card.tsx";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs.tsx";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { supabase } from "@/integrations/supabase/client.ts";
 import { useQuery } from "@tanstack/react-query";
 import { Tables } from "@/types/supabase.ts";
@@ -13,6 +13,13 @@ const Parent = () => {
   const { children, isLoading } = useParentChildren();
   const [selectedStudentId, setSelectedStudentId] = useState<string | null>(children[0]?.id ?? null);
   const { toast: _toast } = useToast();
+
+  // Ensure a default child is selected once children load
+  useEffect(() => {
+    if (!selectedStudentId && children && children.length > 0) {
+      setSelectedStudentId(children[0].id);
+    }
+  }, [children, selectedStudentId]);
 
   const { data: progressEntries } = useQuery({
     queryKey: ["parent-student-progress", selectedStudentId],
@@ -70,19 +77,21 @@ const Parent = () => {
             <CardTitle>Parent Dashboard</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="flex gap-3 flex-wrap">
+            <div className="-mx-1">
+              <div className="flex gap-2 overflow-x-auto whitespace-nowrap px-1 py-1">
               {isLoading && <span>Loading children...</span>}
               {!isLoading && children.length === 0 && <span>No linked children found.</span>}
               {children.map((child) => (
                 <button
                   key={child.id}
                   type="button"
-                  className={`px-3 py-2 rounded border ${selectedStudentId === child.id ? "bg-primary text-primary-foreground" : "bg-background"}`}
+                  className={`px-3 py-2 rounded border shrink-0 ${selectedStudentId === child.id ? "bg-primary text-primary-foreground" : "bg-background"}`}
                   onClick={() => setSelectedStudentId(child.id)}
                 >
                   {child.name}
                 </button>
               ))}
+              </div>
             </div>
           </CardContent>
         </Card>

--- a/src/pages/ParentAcademics.tsx
+++ b/src/pages/ParentAcademics.tsx
@@ -34,9 +34,7 @@ const ParentAcademics = () => {
     }
   }, [children, selectedStudentId]);
 
-  useEffect(() => {
-    console.log("hihihi");
-  }, []);
+  // Remove stray debug log
 
   // Assignments for selected child
   const { data: submissions, isLoading: loadingAssignments } = useQuery({
@@ -156,16 +154,18 @@ const ParentAcademics = () => {
             <CardTitle>Academics</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="flex gap-2 flex-wrap mb-4">
-              {children.map((child) => (
-                <button
-                  key={child.id}
-                  className={`px-3 py-2 rounded border ${selectedStudentId === child.id ? "bg-primary text-primary-foreground" : "bg-background"}`}
-                  onClick={() => setSelectedStudentId(child.id)}
-                >
-                  {child.name}
-                </button>
-              ))}
+            <div className="-mx-1 mb-4">
+              <div className="flex gap-2 overflow-x-auto whitespace-nowrap px-1 py-1">
+                {children.map((child) => (
+                  <button
+                    key={child.id}
+                    className={`px-3 py-2 rounded border shrink-0 ${selectedStudentId === child.id ? "bg-primary text-primary-foreground" : "bg-background"}`}
+                    onClick={() => setSelectedStudentId(child.id)}
+                  >
+                    {child.name}
+                  </button>
+                ))}
+              </div>
             </div>
             <Tabs defaultValue="assignments" className="w-full">
               <TabsList className="grid grid-cols-2 sm:grid-cols-3 w-full">
@@ -257,7 +257,7 @@ const ParentAcademics = () => {
                       )}
                     </TableBody>
                   </Table>
-            </div>
+                </div>
               </TabsContent>
 
               <TabsContent value="grades" className="mt-4">

--- a/src/pages/ParentAttendance.tsx
+++ b/src/pages/ParentAttendance.tsx
@@ -1,6 +1,6 @@
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute.tsx";
 import { useParentChildren } from "@/hooks/useParentChildren.ts";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card.tsx";
 import { supabase } from "@/integrations/supabase/client.ts";
 import { useQuery } from "@tanstack/react-query";
@@ -9,6 +9,13 @@ import { Tables } from "@/types/supabase.ts";
 const ParentAttendance = () => {
   const { children } = useParentChildren();
   const [selectedStudentId, setSelectedStudentId] = useState<string | null>(children[0]?.id ?? null);
+
+  // Ensure a default child is selected once children load
+  useEffect(() => {
+    if (!selectedStudentId && children && children.length > 0) {
+      setSelectedStudentId(children[0].id);
+    }
+  }, [children, selectedStudentId]);
 
   const { data: attendance } = useQuery<Tables["attendance"][] | null>({
     queryKey: ["parent-student-attendance", selectedStudentId],
@@ -34,22 +41,24 @@ const ParentAttendance = () => {
             <CardTitle>Attendance</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="flex gap-2 flex-wrap mb-4">
-              {children.map((child) => (
-                <button
-                  key={child.id}
-                  className={`px-3 py-2 rounded border ${selectedStudentId === child.id ? "bg-primary text-primary-foreground" : "bg-background"}`}
-                  onClick={() => setSelectedStudentId(child.id)}
-                >
-                  {child.name}
-                </button>
-              ))}
+            <div className="-mx-1 mb-4">
+              <div className="flex gap-2 overflow-x-auto whitespace-nowrap px-1 py-1">
+                {children.map((child) => (
+                  <button
+                    key={child.id}
+                    className={`px-3 py-2 rounded border shrink-0 ${selectedStudentId === child.id ? "bg-primary text-primary-foreground" : "bg-background"}`}
+                    onClick={() => setSelectedStudentId(child.id)}
+                  >
+                    {child.name}
+                  </button>
+                ))}
+              </div>
             </div>
             <ul className="space-y-2">
               {(attendance || []).map((a: any) => (
-                <li key={a.id} className="p-3 rounded border flex justify-between">
-                  <span>{a.date}</span>
-                  <span className="uppercase">{a.status}</span>
+                <li key={a.id} className="p-3 rounded border flex flex-col sm:flex-row sm:justify-between gap-1">
+                  <span className="text-sm text-muted-foreground">{a.date}</span>
+                  <span className="uppercase font-medium">{a.status}</span>
                 </li>
               ))}
             </ul>

--- a/src/pages/ParentProgress.tsx
+++ b/src/pages/ParentProgress.tsx
@@ -1,6 +1,6 @@
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute.tsx";
 import { useParentChildren } from "@/hooks/useParentChildren.ts";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card.tsx";
 import { DhorBook } from "@/components/dhor-book/DhorBook.tsx";
 import { subDays, startOfWeek, endOfWeek, format } from "date-fns";
@@ -10,6 +10,13 @@ import { useQuery } from "@tanstack/react-query";
 const ParentProgress = () => {
   const { children } = useParentChildren();
   const [selectedStudentId, setSelectedStudentId] = useState<string | null>(children[0]?.id ?? null);
+
+  // Ensure a default child is selected once children load
+  useEffect(() => {
+    if (!selectedStudentId && children && children.length > 0) {
+      setSelectedStudentId(children[0].id);
+    }
+  }, [children, selectedStudentId]);
 
   const { data: weekly } = useQuery({
     queryKey: ["parent-student-progress-weekly", selectedStudentId],
@@ -53,16 +60,18 @@ const ParentProgress = () => {
             <CardTitle>Qur'an Progress</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="flex gap-2 flex-wrap mb-4">
-              {children.map((child) => (
-                <button
-                  key={child.id}
-                  className={`px-3 py-2 rounded border ${selectedStudentId === child.id ? "bg-primary text-primary-foreground" : "bg-background"}`}
-                  onClick={() => setSelectedStudentId(child.id)}
-                >
-                  {child.name}
-                </button>
-              ))}
+            <div className="-mx-1 mb-4">
+              <div className="flex gap-2 overflow-x-auto whitespace-nowrap px-1 py-1">
+                {children.map((child) => (
+                  <button
+                    key={child.id}
+                    className={`px-3 py-2 rounded border shrink-0 ${selectedStudentId === child.id ? "bg-primary text-primary-foreground" : "bg-background"}`}
+                    onClick={() => setSelectedStudentId(child.id)}
+                  >
+                    {child.name}
+                  </button>
+                ))}
+              </div>
             </div>
             {selectedStudentId && (
               <DhorBook


### PR DESCRIPTION
Refactored the child selector in Parent, ParentAcademics, ParentAttendance, and ParentProgress pages to use a horizontally scrollable button group for better usability with many children. Added useEffect hooks to ensure a default child is selected when children data loads. Removed stray debug log from ParentAcademics.