### PR TITLE
Phase 3 + DB cleanup + Admin UX consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Dhor book — revision sessions. Key fields: `id`, `student_id`, `revision_date`
 ### parent_children
 Parent ↔ student mapping. Key fields: `parent_id`, `student_id`.
 
-### roles / role_permissions
-RBAC model. Permissions shape `capabilities` JSONB on profiles and UI visibility via `useRBAC`.
+### roles
+RBAC model. The `role` field on `profiles` (admin / teacher / parent) drives `capabilities` JSONB and UI visibility via `useRBAC`. The legacy `role_permissions` table was dropped on 2026-05-11 (unused, replaced by hardcoded `useRBAC` rules).
 
 ---
 

--- a/abdul.wiki
+++ b/abdul.wiki
@@ -228,7 +228,7 @@ The attendance page is the primary monitoring surface. Key features:
 ## Navigation Config
 
 `src/config/navigation.ts` defines nav items per role:
-- **adminNavItems** — 16 items (Dashboard, Students, Teachers, Classes, ProgressBook, Attendance, Calendar, TeacherSchedules, Tasks, ParentAccounts, BulkImport, AbsenceRequests, Activity, CommunicationTemplates, Reports, Interviews)
+- **adminNavItems** — 11 items (Dashboard, Students, Teachers, Classes, ProgressBook, Attendance, Calendar, Reports, Tasks, ParentAccounts, AdminPanel). Reduced from 16 on 2026-05-11 by consolidating 6 low-frequency items (BulkImport, CommunicationTemplates, Activity, AbsenceRequests, TeacherSchedules, Interviews) into a tabbed hub at `/admin/panel`.
 - **teacherNavItems** — 8 items (filtered by capability: attendance, progress, assignments)
 - **parentNavItems** — 7 items (ParentDashboard, Agenda, QuranProgress, Attendance, Academics, Messages, Interviews)
 
@@ -276,6 +276,7 @@ Between any two pushes, an automated release bot commits a `CHANGELOG.md` update
 
 | Date | Summary | See Also |
 |---|---|---|
+| 2026-05-11 (s3) | Admin UX consolidation: sidebar 16 → 11 items via new `/admin/panel` tabbed hub (Bulk Import / Templates / Activity / Interviews / Schedules / Absences); old URLs redirect to `?tab=` deep links; AdminLayout secondary sidebar trimmed to dev-only pages; Dashboard cleaned: fake hardcoded weekly bars replaced with real attendance query, fake 74% donut fallback → "—", fake Remind Teachers button removed, broken `?tab=performance` links repointed to `/admin/reports`, redundant Quick Nav grid deleted, welcome banner duplicate buttons collapsed | handoff.md |
 | 2026-05-11 (s2) | DB cleanup: dropped 5 dead empty tables (analytics_alerts, analytics_summary, class_metrics_summary, student_metrics_summary, role_permissions); resolved orphan duplicate profile (maimoona.ansari admin row, no auth.users); added LOWER(email) UNIQUE index on profiles; enabled RLS + admin-only policies on app_settings, email_logs, attendance_settings, attendance_absence_notifications; ran ANALYZE; final 28 base tables, 0 dups, 0 RLS gaps | handoff.md |
 | 2026-05-11 | Phase 3 — Interview Scheduling + CSV Export: 3-table interview system (interview_windows, interview_slots, interview_bookings) with RLS; /admin/interviews (create windows, generate slots per teacher, view/cancel bookings); /parent/interviews (browse open windows, book slot with child selector, cancel booking); send-interview-confirmation edge function (Resend, DUM green header, slot + student + teacher details); Reports.tsx filter bar (date range + section filter, Full Attendance Log new report type, query keys include filters); nav: Interviews added to adminNavItems + parentNavItems; i18n: interviews en/fr | handoff.md, ROADMAP.md |
 | 2026-05-09 | Phase 2 — Parent UX: weekly agenda (/parent/agenda) with class-grid + school events overlay; Hifz Report Card printable view (/students/:id/report-card) with Cmd+P → PDF; student photo upload (Supabase student-photos bucket + photo_url column) wired into Dialog/Detail/Popover/list; parent assignment submission (SubmitAssignmentDialog, parent_note column, assignment-submissions bucket, upsert on (assignment_id, student_id)); ParentAcademics action buttons; Parent dashboard graded badge | handoff.md, ROADMAP.md |

--- a/abdul.wiki
+++ b/abdul.wiki
@@ -127,6 +127,10 @@ The core purpose: track every student's Quran memorization journey, monitor atte
 | `parent_children` | Parent→student linkage (legacy/fallback) |
 | `notifications` | In-app notification queue; also used for overdue-email de-duplication (assignment_id + recipient_id + date) |
 | `analytics_metrics` | Pre-aggregated analytics data |
+| `app_settings` | Global app config (admin-only RW; RLS enabled 2026-05-11) |
+| `email_logs` | All Resend dispatches (admin-only SELECT; service_role inserts; RLS enabled 2026-05-11) |
+| `attendance_settings` | Cutoff times + attendance rules (admin RW, teacher SELECT; RLS enabled 2026-05-11) |
+| `attendance_absence_notifications` | Per-day per-student absence email dedup ledger (admin RW, teacher SELECT; RLS enabled 2026-05-11) |
 | `teacher_tasks` | Tasks assigned by admin to teachers — priority (low/medium/high/urgent), status (pending/in_progress/done), due_date, notes |
 | `announcements` | Class announcements from teachers — title, message, class_id, sent_to_count |
 | `absence_requests` | Teacher absence requests — date range, reason, status (pending/approved/rejected), admin_note, reviewed_by |
@@ -139,6 +143,11 @@ The core purpose: track every student's Quran memorization journey, monitor atte
 
 ### Row Level Security
 All tables have RLS policies. Teachers see only their students. Parents see only their children's data. Admins have full access.
+
+**2026-05-11 hardening:** RLS enabled on `app_settings`, `email_logs`, `attendance_settings`, `attendance_absence_notifications` (previously exposed to anon role). Edge functions writing to these tables use `service_role` which bypasses RLS.
+
+### Profile uniqueness
+`profiles.email` has a case-insensitive UNIQUE index (`profiles_email_unique_idx ON LOWER(email)`) since 2026-05-11 to prevent duplicate accounts.
 
 ---
 
@@ -267,6 +276,7 @@ Between any two pushes, an automated release bot commits a `CHANGELOG.md` update
 
 | Date | Summary | See Also |
 |---|---|---|
+| 2026-05-11 (s2) | DB cleanup: dropped 5 dead empty tables (analytics_alerts, analytics_summary, class_metrics_summary, student_metrics_summary, role_permissions); resolved orphan duplicate profile (maimoona.ansari admin row, no auth.users); added LOWER(email) UNIQUE index on profiles; enabled RLS + admin-only policies on app_settings, email_logs, attendance_settings, attendance_absence_notifications; ran ANALYZE; final 28 base tables, 0 dups, 0 RLS gaps | handoff.md |
 | 2026-05-11 | Phase 3 — Interview Scheduling + CSV Export: 3-table interview system (interview_windows, interview_slots, interview_bookings) with RLS; /admin/interviews (create windows, generate slots per teacher, view/cancel bookings); /parent/interviews (browse open windows, book slot with child selector, cancel booking); send-interview-confirmation edge function (Resend, DUM green header, slot + student + teacher details); Reports.tsx filter bar (date range + section filter, Full Attendance Log new report type, query keys include filters); nav: Interviews added to adminNavItems + parentNavItems; i18n: interviews en/fr | handoff.md, ROADMAP.md |
 | 2026-05-09 | Phase 2 — Parent UX: weekly agenda (/parent/agenda) with class-grid + school events overlay; Hifz Report Card printable view (/students/:id/report-card) with Cmd+P → PDF; student photo upload (Supabase student-photos bucket + photo_url column) wired into Dialog/Detail/Popover/list; parent assignment submission (SubmitAssignmentDialog, parent_note column, assignment-submissions bucket, upsert on (assignment_id, student_id)); ParentAcademics action buttons; Parent dashboard graded badge | handoff.md, ROADMAP.md |
 | 2026-05-08 (s3) | Phase 1 — Stabilization: 10 bug fixes (validation, .maybeSingle, CSV escape, madrassah scoping, setState-during-render); Sentry wiring; TS noUnusedLocals + noUnusedParameters; Vitest + 14 critical-path tests; build verified ✓ 48s; 3 email cron jobs paused (jobids 5, 34, 35) until manual smoke test; Finder dupes deleted; .env removed from git; useAttendanceMutation/useStudentsQuery/createTeacherAccount removed; stale branches Abdul/Nazif/claude/* deleted; dev synced to main | handoff.md, ROADMAP.md |

--- a/abdul.wiki
+++ b/abdul.wiki
@@ -72,30 +72,39 @@ The core purpose: track every student's Quran memorization journey, monitor atte
 - `/admin/parent-accounts` — Manage parent accounts
 - `/admin/bulk-student-import` — CSV student import
 - `/admin/teacher-schedules` — View teacher schedules
+- `/admin/communication-templates` — Manage message templates
+- `/admin/reports` — Generate + export CSV reports (date/section filtered)
+- `/admin/interviews` — Create interview windows, generate slots, manage bookings
 - `/admin/setup` — First-time setup wizard
 - `/admin/roles` — Manual role assignment
 
 ### Main App (protected, under `DashboardLayout`)
 - `/dashboard` — Role-based hub (Teacher Portal or Admin Portal)
 - `/parent` — Parent dashboard
+- `/parent/agenda` — Weekly class schedule grid (Mon–Sat × hour slots)
 - `/parent/progress` — Child's Quran progress
-- `/parent/academics` — Assignments with status filtering
+- `/parent/academics` — Assignments with status filtering + submission upload
 - `/parent/attendance` — Attendance history
 - `/parent/messages` — Teacher messaging
+- `/parent/interviews` — Book parent-teacher interview slots
 - `/students` — Student roster
 - `/students/:id` — Individual student profile
+- `/students/:id/report-card` — Printable Hifz Report Card (Cmd+P → PDF)
 - `/teachers` — Teacher roster
 - `/classes` — Class management
 - `/progress-book` — Dhor book entry (teacher)
 - `/attendance` — Bulk attendance form (teacher)
 - `/messages` — Teacher messaging
 - `/schedule` — Teacher schedule
+- `/calendar` — School calendar (events, holidays, PD days; audience: all/teachers/parents)
+- `/tasks` — Task list (admin assigns to teachers)
+- `/absence-requests` — Teacher absence request review (admin)
 - `/teacher-accounts` — Manage teacher accounts (admin)
 - `/add-parent` — Link parent to student (teacher)
+- `/profile` — Edit own name/phone/bio + change password
 - `/settings` — System settings
 - `/preferences` — User preferences
 - `/activity` — Activity feed (admin)
-- `/calendar` — School calendar (events, holidays, PD days) — all roles
 
 ### Dev-only (gated)
 - `/dev/seeder`, `/dev/create-demo`, `/dev/create-teacher-profile`, etc.
@@ -122,6 +131,11 @@ The core purpose: track every student's Quran memorization journey, monitor atte
 | `announcements` | Class announcements from teachers — title, message, class_id, sent_to_count |
 | `absence_requests` | Teacher absence requests — date range, reason, status (pending/approved/rejected), admin_note, reviewed_by |
 | `school_events` | Calendar events — title, event_type, start_date, end_date, color, audience (all/teachers/parents) |
+| `communication_templates` | Admin-managed reusable message templates — name, subject, body, category |
+| `teacher_assignment_submissions` | Parent file uploads for assignments — file_url, parent_note, upserts on (assignment_id, student_id) |
+| `interview_windows` | Admin-created interview blocks — title, description, start_date, end_date, slot_duration_minutes |
+| `interview_slots` | Bookable 15-min slots — window_id, teacher_id, slot_date, slot_time; UNIQUE booking prevents double-booking |
+| `interview_bookings` | Parent bookings — slot_id (UNIQUE), student_id, parent_id, notes, status (confirmed/cancelled/no_show) |
 
 ### Row Level Security
 All tables have RLS policies. Teachers see only their students. Parents see only their children's data. Admins have full access.
@@ -145,6 +159,7 @@ All emails go through **Resend** via Supabase Edge Functions:
 | `send-assignment-overdue` | Daily at 08:00 UTC via pg_cron — scans overdue ungraded assignments, emails parents; de-duped via `notifications` table |
 | `send-enrollment-confirmation` | When a new student is added (POST `{ student_id }`) — emails all admin accounts |
 | `send-class-announcement` | When teacher broadcasts a class announcement (POST `{ announcement_id }`) — emails all class parents, updates `sent_to_count` |
+| `send-interview-confirmation` | When parent books an interview slot (POST `{ slot_id, student_id, parent_id }`) — emails parent with date/time/teacher/student details |
 
 Required env secrets: `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `APP_URL`, `LOGO_URL`
 
@@ -204,9 +219,9 @@ The attendance page is the primary monitoring surface. Key features:
 ## Navigation Config
 
 `src/config/navigation.ts` defines nav items per role:
-- **adminNavItems** — 11 items (Dashboard, Analytics, Students, Teachers, Classes, ProgressBook, Attendance, ParentAccounts, BulkImport, TeacherSchedules, Settings)
+- **adminNavItems** — 16 items (Dashboard, Students, Teachers, Classes, ProgressBook, Attendance, Calendar, TeacherSchedules, Tasks, ParentAccounts, BulkImport, AbsenceRequests, Activity, CommunicationTemplates, Reports, Interviews)
 - **teacherNavItems** — 8 items (filtered by capability: attendance, progress, assignments)
-- **parentNavItems** — 6 items (ParentDashboard, AddParent, Messages, QuranProgress, Academics, Attendance)
+- **parentNavItems** — 7 items (ParentDashboard, Agenda, QuranProgress, Attendance, Academics, Messages, Interviews)
 
 ---
 
@@ -252,6 +267,7 @@ Between any two pushes, an automated release bot commits a `CHANGELOG.md` update
 
 | Date | Summary | See Also |
 |---|---|---|
+| 2026-05-11 | Phase 3 — Interview Scheduling + CSV Export: 3-table interview system (interview_windows, interview_slots, interview_bookings) with RLS; /admin/interviews (create windows, generate slots per teacher, view/cancel bookings); /parent/interviews (browse open windows, book slot with child selector, cancel booking); send-interview-confirmation edge function (Resend, DUM green header, slot + student + teacher details); Reports.tsx filter bar (date range + section filter, Full Attendance Log new report type, query keys include filters); nav: Interviews added to adminNavItems + parentNavItems; i18n: interviews en/fr | handoff.md, ROADMAP.md |
 | 2026-05-09 | Phase 2 — Parent UX: weekly agenda (/parent/agenda) with class-grid + school events overlay; Hifz Report Card printable view (/students/:id/report-card) with Cmd+P → PDF; student photo upload (Supabase student-photos bucket + photo_url column) wired into Dialog/Detail/Popover/list; parent assignment submission (SubmitAssignmentDialog, parent_note column, assignment-submissions bucket, upsert on (assignment_id, student_id)); ParentAcademics action buttons; Parent dashboard graded badge | handoff.md, ROADMAP.md |
 | 2026-05-08 (s3) | Phase 1 — Stabilization: 10 bug fixes (validation, .maybeSingle, CSV escape, madrassah scoping, setState-during-render); Sentry wiring; TS noUnusedLocals + noUnusedParameters; Vitest + 14 critical-path tests; build verified ✓ 48s; 3 email cron jobs paused (jobids 5, 34, 35) until manual smoke test; Finder dupes deleted; .env removed from git; useAttendanceMutation/useStudentsQuery/createTeacherAccount removed; stale branches Abdul/Nazif/claude/* deleted; dev synced to main | handoff.md, ROADMAP.md |
 | 2026-05-07 (s4) | Communication templates: new Supabase table + RLS, 6 seeded Islamic templates, useCommunicationTemplates hook, /admin/communication-templates page (category pills, card grid, CRUD); admin edit users: TeacherEditDialog adds location field, ParentEditDialog (name/email/phone), pencil button in ParentAccounts | handoff.md |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,7 @@ ProtectedRoute checks AuthContext
 | `juz_revisions` | Dhor book — revision sessions per juz/quarter |
 | `parent_children` | Parent ↔ student mapping |
 | `parents` | Parent records with `student_ids` array |
-| `roles / role_permissions` | RBAC model — granular permissions shaping `capabilities` JSONB |
+| `roles` | RBAC role enum (admin/teacher/parent); legacy `role_permissions` table dropped 2026-05-11 |
 | `communications` | Teacher ↔ admin messaging |
 | `email_logs` | Daily digest send history |
 | `app_settings` | Application-level configuration |

--- a/handoff.md
+++ b/handoff.md
@@ -4,6 +4,46 @@ This file is **non-negotiable**. Every meaningful change must be logged here.
 
 ---
 
+## 2026-05-11 (s2) — DB Cleanup: Dead Tables, Profile Dups, RLS Hardening
+
+**What:** End-of-day database hygiene pass on `depsfpodwaprzxffdcks`.
+
+**Audit results (before):**
+- 0 orphan attendance/progress, 0 duplicate students, 0 duplicate attendance rows — integrity already clean
+- `pg_stat_user_tables` was massively stale (showed `parents`=2, real=121; `profiles`=3, real=144)
+- 5 dead empty tables with zero code refs: `analytics_alerts`, `analytics_summary`, `class_metrics_summary`, `student_metrics_summary`, `role_permissions`
+- 1 duplicate `profiles.email` (`maimoona.ansari@gmail.com`) — orphan admin row (no `auth.users`, no `parents` link) + real parent row with linked child
+- 4 tables with RLS disabled and exposed to anon role: `app_settings`, `email_logs`, `attendance_settings`, `attendance_absence_notifications`
+
+**Migrations applied live:**
+
+`supabase/migrations/20260511010000_cleanup_dead_tables_and_dup_profile.sql`:
+- `DROP TABLE` × 5 (analytics_alerts, analytics_summary, class_metrics_summary, student_metrics_summary, role_permissions) with CASCADE
+- `DELETE` orphan admin profile row (id `794ca656-d5c8-4c28-bb36-e6f58baaa34e`) — kept the real parent row (id `f70161a4-755b-46f6-b202-3b128c975aa6`) which is wired to auth.users + linked to student `325d3a00-...`
+- `CREATE UNIQUE INDEX profiles_email_unique_idx ON profiles (LOWER(email))` — prevents future email dups
+
+`supabase/migrations/20260511020000_enable_rls_unprotected_tables.sql`:
+- `ENABLE ROW LEVEL SECURITY` on all 4 unprotected tables
+- Policies:
+  - `app_settings`: admin-only RW
+  - `email_logs`: admin-only SELECT (service_role bypasses RLS for inserts from edge functions)
+  - `attendance_settings`: admin RW + teacher SELECT
+  - `attendance_absence_notifications`: admin RW + teacher SELECT
+
+**Other:**
+- `ANALYZE;` run to refresh stale planner stats
+
+**Verification (after):**
+- 28 base tables (was 33)
+- 0 duplicate emails in profiles
+- 0 RLS-disabled tables in the previously-flagged set
+- get_advisors security clean for the 4 fixed tables
+
+**Skipped this session (user decision):**
+- Pruning `email_logs` and `attendance_absence_notifications` older than 90 days (no urgency)
+
+---
+
 ## 2026-05-11 — Phase 3: Interview Scheduling + Bulk Attendance CSV Export
 
 **What:** Phase 3 items 3.1 (L) and 3.3 (S) shipped.

--- a/handoff.md
+++ b/handoff.md
@@ -4,6 +4,55 @@ This file is **non-negotiable**. Every meaningful change must be logged here.
 
 ---
 
+## 2026-05-11 (s3) — Admin UX Consolidation (B + C + F)
+
+**What:** Sidebar 16 → 11 items; new tabbed hub at `/admin/panel`; admin Dashboard cleaned of fake data + broken links + redundant buttons.
+
+### B + C: Sidebar consolidation + tabbed hub
+
+**New file** `src/pages/admin/AdminPanel.tsx` (one page, shadcn `Tabs`, `?tab=` deep-linked, wraps existing pages directly — no body extraction needed since each page already uses `AdminPageShell`):
+- Tabs: Bulk Import / Templates / Activity Log / Interviews / Teacher Schedules / Absence Requests
+- URL: `/admin/panel?tab=<id>` — deep-linkable, defaults to `bulk-import`
+- Wrapped in `DashboardLayout` so the main sidebar stays visible
+
+**Sidebar trim** (`src/config/navigation.ts`):
+- REMOVED: BulkImport, CommunicationTemplates, ActivityFeed, AbsenceRequests, TeacherSchedules, Interviews
+- ADDED: single "Admin Panel" entry (Settings icon) under Admin section
+- Reports stays as direct sidebar entry (high-frequency)
+- Final count: 11 items (Dashboard / Students / Teachers / Classes / ProgressBook / Attendance / Calendar / Reports / Tasks / ParentAccounts / AdminPanel)
+
+**Old URLs → redirects** (`src/App.tsx`):
+- `/admin/communication-templates` → `/admin/panel?tab=templates`
+- `/admin/interviews` → `/admin/panel?tab=interviews`
+- `/admin/bulk-student-import` → `/admin/panel?tab=bulk-import`
+- `/admin/teacher-schedules` → `/admin/panel?tab=schedules`
+- `/activity` → `/admin/panel?tab=activity`
+- `/absence-requests` → `/admin/panel?tab=absences`
+- All bookmarks keep working
+
+**AdminLayout sidebar trim** (`src/pages/admin/AdminLayout.tsx`): the secondary `/admin/*` sidebar now only shows true dev pages (Setup / Roles / Seeder / Admin Creator / Parent Accounts / Settings). TeacherSchedules + bulk-import sub-routes removed (replaced by redirects).
+
+**i18n** (`src/i18n/translations.ts`): `adminPanel: "Admin Panel"` / `"Panneau Admin"`.
+
+### F: Admin Dashboard cleanup (`src/components/admin/AdminDashboard.tsx`)
+
+| Change | Before | After |
+|---|---|---|
+| Weekly attendance chart | Hardcoded fake `[42, 91, 88, 74, 83, 60, 28]` array | Real `useQuery` against `attendance` table for last 7 days, computed % per day |
+| Donut fallback | Showed fake `74%` when real value is 0 | Shows `—` |
+| "Remind Teachers" button | Fake toast, no email actually sent | REMOVED (false-positive UX worse than no button) |
+| Welcome banner buttons | 2 buttons both navigating to `/students` | Collapsed to 1 "Manage Students" button |
+| "View all" alerts link | `/dashboard?tab=performance` (no such tab exists) | `/admin/reports` |
+| "View Performance" alert button | Same broken link | `/admin/reports` |
+| Staff "Manage" button | `/dashboard?tab=students` (broken) | `/teachers` |
+| Quick Nav grid (4 cards) | Duplicated sidebar items (Students/Attendance/Classes/Analytics) | DELETED entire grid |
+
+**Net buttons:** ~14 → ~6 meaningful actions on the dashboard.
+
+**Build:** `npm run build` ✓ exit 0, 5.02s, no new warnings.
+
+---
+
 ## 2026-05-11 (s2) — DB Cleanup: Dead Tables, Profile Dups, RLS Hardening
 
 **What:** End-of-day database hygiene pass on `depsfpodwaprzxffdcks`.

--- a/handoff.md
+++ b/handoff.md
@@ -4,6 +4,58 @@ This file is **non-negotiable**. Every meaningful change must be logged here.
 
 ---
 
+## 2026-05-11 — Phase 3: Interview Scheduling + Bulk Attendance CSV Export
+
+**What:** Phase 3 items 3.1 (L) and 3.3 (S) shipped.
+
+### 3.1 Parent-Teacher Interview Scheduling
+
+**DB migration** (`supabase/migrations/20260511000000_create_interview_tables.sql`) — applied live to `depsfpodwaprzxffdcks`:
+- `interview_windows(id, title, description, start_date, end_date, slot_duration_minutes, created_by, created_at)`
+- `interview_slots(id, window_id, teacher_id, slot_date, slot_time, duration_minutes, created_at)`
+- `interview_bookings(id, slot_id, student_id, parent_id, notes, status, created_at)` — UNIQUE on `slot_id` (prevents double-booking)
+- RLS: windows/slots are public-read, admin-write; bookings are admin/teacher-read, parent-own-read, parent-insert, admin-update/delete
+
+**Admin panel** (`src/pages/admin/Interviews.tsx` at `/admin/interviews`):
+- 3 pill tabs: Interview Windows / Manage Slots / Bookings
+- "New Window" dialog: title, description, date range, slot duration (10/15/20/30 min)
+- "Generate Slots" dialog: pick window + teacher + date + start/end time → auto-generates N-minute slots via frontend loop → bulk inserts
+- Bookings table: date/time, teacher, student, parent, status; Cancel/No-show buttons
+
+**Parent booking page** (`src/pages/ParentInterviews.tsx` at `/parent/interviews`):
+- Shows open windows (end_date ≥ today) as expandable cards
+- Slots grouped by teacher → date → time pill buttons (green=mine, gray=booked, white=available)
+- Click slot → confirm dialog → select child (if multiple) → add notes → insert booking → calls edge function
+- "My Bookings" banner at top with cancel option
+
+**Edge function** (`supabase/functions/send-interview-confirmation/index.ts`) — deployed live (v1):
+- POST `{ slot_id, student_id, parent_id }`
+- Sends HTML email to parent: date, time, teacher name, student name, deep link to `/parent/interviews`
+- DUM green gradient header, matches other email templates
+
+**Navigation + i18n:**
+- Admin sidebar: "Interviews" with CalendarCheck icon under Admin Tools
+- Parent sidebar: "Interviews" with CalendarCheck icon
+- i18n: `interviews: "Interviews"` / `"Entretiens"` in en + fr nav sections
+
+### 3.3 Bulk Attendance CSV Export
+
+**Modified** `src/pages/admin/Reports.tsx`:
+- New filter bar card at top: Date From, Date To, Section dropdown (men/women/Henri-Bourassa/Saint-Laurent), Reset button
+- Filter state defaults to current month (first → today), section = all
+- `fetchAttendanceByStudent` + `fetchAttendanceBySection` both now accept filters: `.gte("date", dateFrom)`, `.lte("date", dateTo)`, `.eq("section", section)` on student query
+- New **"Full Attendance Log"** report: raw date-stamped records with Date, Student Name, Section, Status, Notes columns — designed for government/external reporting
+- React Query keys include filter object — changing any filter clears cached data
+
+**Build:** `npm run build` ✓ exit 0, 4.91s (no new warnings vs. baseline)
+
+**Pending from Phase 3:**
+- 3.2 Transport/Pickup Confirmation (M)
+- 3.4 Secretary test accounts (S)
+- Email crons 5, 34, 35 still paused — run smoke test before re-enabling
+
+---
+
 ## 2026-05-09 — Phase 2: Parent UX (4 features in parallel)
 
 **What:** Phase 2 of ROADMAP. 4 parent-facing features built in parallel via subagents:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,8 @@ import BulkStudentImport from "@/pages/admin/BulkStudentImport.tsx";
 import Activity from "@/pages/admin/Activity.tsx";
 import CommunicationTemplates from "@/pages/admin/CommunicationTemplates.tsx";
 import Reports from "@/pages/admin/Reports.tsx";
+import Interviews from "@/pages/admin/Interviews.tsx";
+import ParentInterviews from "@/pages/ParentInterviews.tsx";
 import ResetPassword from "@/pages/ResetPassword.tsx";
 import SchoolCalendar from "@/pages/SchoolCalendar.tsx";
 import TeacherAddParent from "@/pages/TeacherAddParent.tsx";
@@ -134,6 +136,16 @@ function App() {
               </ProtectedRoute>
             }
           />
+          <Route
+            path="/admin/interviews"
+            element={
+              <ProtectedRoute requireAdmin>
+                <DashboardLayout>
+                  <Interviews />
+                </DashboardLayout>
+              </ProtectedRoute>
+            }
+          />
           {/* Admin Activity in main sidebar (not inside Admin Panel) */}
           <Route
             path="/activity"
@@ -202,6 +214,14 @@ function App() {
               element={
                 <ProtectedRoute requireParent>
                   <ParentAgenda />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/parent/interviews"
+              element={
+                <ProtectedRoute requireParent>
+                  <ParentInterviews />
                 </ProtectedRoute>
               }
             />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,6 @@ import Preferences from "@/pages/Preferences.tsx";
 import CreateDemoAccount from "@/pages/dev/CreateDemoAccount.tsx";
 import CreateTeacherProfileForTestAccount from "@/pages/dev/CreateTeacherProfileForTestAccount.tsx";
 import DatabaseSeeder from "@/pages/dev/DatabaseSeeder.tsx";
-import TeacherSchedules from "@/pages/admin/TeacherSchedules.tsx";
 import SetupAdmin from "@/pages/admin/SetupAdmin.tsx";
 import ManualRoleSetup from "@/pages/dev/ManualRoleSetup.tsx";
 import AdminLayout from "@/pages/admin/AdminLayout.tsx";
@@ -47,11 +46,8 @@ import ParentAcademics from "@/pages/ParentAcademics.tsx";
 import ParentAgenda from "@/pages/ParentAgenda.tsx";
 import ParentAttendance from "@/pages/ParentAttendance.tsx";
 import ParentAccounts from "@/pages/admin/ParentAccounts.tsx";
-import BulkStudentImport from "@/pages/admin/BulkStudentImport.tsx";
-import Activity from "@/pages/admin/Activity.tsx";
-import CommunicationTemplates from "@/pages/admin/CommunicationTemplates.tsx";
 import Reports from "@/pages/admin/Reports.tsx";
-import Interviews from "@/pages/admin/Interviews.tsx";
+import AdminPanel from "@/pages/admin/AdminPanel.tsx";
 import ParentInterviews from "@/pages/ParentInterviews.tsx";
 import ResetPassword from "@/pages/ResetPassword.tsx";
 import SchoolCalendar from "@/pages/SchoolCalendar.tsx";
@@ -60,7 +56,6 @@ import TeacherMessages from "@/pages/TeacherMessages.tsx";
 import ParentMessages from "@/pages/ParentMessages.tsx";
 import Profile from "@/pages/Profile.tsx";
 import Tasks from "@/pages/Tasks.tsx";
-import AbsenceRequests from "@/pages/AbsenceRequests.tsx";
 
 /**
  * @component App
@@ -112,20 +107,19 @@ function App() {
             <Route path="seeder" element={<DatabaseSeeder />} />
             <Route path="admin-creator" element={<DevAdminManagement />} />
             <Route path="parent-accounts" element={<ParentAccounts />} />
-            <Route path="bulk-student-import" element={<BulkStudentImport />} />
-            <Route path="teacher-schedules" element={<TeacherSchedules />} />
           </Route>
-          {/* Admin pages served inside DashboardLayout (main sidebar) */}
+          {/* Admin Panel — consolidated tabbed hub for low-frequency tools */}
           <Route
-            path="/admin/communication-templates"
+            path="/admin/panel"
             element={
               <ProtectedRoute requireAdmin>
                 <DashboardLayout>
-                  <CommunicationTemplates />
+                  <AdminPanel />
                 </DashboardLayout>
               </ProtectedRoute>
             }
           />
+          {/* High-frequency admin pages stay direct in main sidebar */}
           <Route
             path="/admin/reports"
             element={
@@ -136,37 +130,13 @@ function App() {
               </ProtectedRoute>
             }
           />
-          <Route
-            path="/admin/interviews"
-            element={
-              <ProtectedRoute requireAdmin>
-                <DashboardLayout>
-                  <Interviews />
-                </DashboardLayout>
-              </ProtectedRoute>
-            }
-          />
-          {/* Admin Activity in main sidebar (not inside Admin Panel) */}
-          <Route
-            path="/activity"
-            element={
-              <ProtectedRoute>
-                <DashboardLayout>
-                  <Activity />
-                </DashboardLayout>
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/absence-requests"
-            element={
-              <ProtectedRoute requireAdmin>
-                <DashboardLayout>
-                  <AbsenceRequests />
-                </DashboardLayout>
-              </ProtectedRoute>
-            }
-          />
+          {/* Old admin URLs → redirect to corresponding Admin Panel tab */}
+          <Route path="/admin/communication-templates" element={<Navigate to="/admin/panel?tab=templates" replace />} />
+          <Route path="/admin/interviews" element={<Navigate to="/admin/panel?tab=interviews" replace />} />
+          <Route path="/admin/bulk-student-import" element={<Navigate to="/admin/panel?tab=bulk-import" replace />} />
+          <Route path="/admin/teacher-schedules" element={<Navigate to="/admin/panel?tab=schedules" replace />} />
+          <Route path="/activity" element={<Navigate to="/admin/panel?tab=activity" replace />} />
+          <Route path="/absence-requests" element={<Navigate to="/admin/panel?tab=absences" replace />} />
 
           <Route
             element={

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -11,22 +11,18 @@ import { useNavigate } from "react-router-dom";
 import {
   AlertTriangle,
   ArrowUpRight,
-  Bell,
   BookOpen,
   Calendar,
   CalendarX,
   CheckCircle2,
-  ClipboardList,
   GraduationCap,
   HelpCircle,
   MapPin,
   Plus,
   TrendingUp,
   UserCheck,
-  Users,
 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext.tsx";
-import { useToast } from "@/hooks/use-toast.ts";
 import { StudentContactPopover } from "@/components/attendance/StudentContactPopover.tsx";
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -175,27 +171,16 @@ const Pill = ({
   </div>
 );
 
-// ─── Attendance Bar Chart ─────────────────────────────────────────────────────
+// ─── Attendance Bar Chart (real data from last 7 days) ───────────────────────
 
-const weekDays = [
-  { day: "S", pct: 42 },
-  { day: "M", pct: 91 },
-  { day: "T", pct: 88 },
-  { day: "W", pct: 74, highlight: true },
-  { day: "T", pct: 83 },
-  { day: "F", pct: 60 },
-  { day: "S", pct: 28 },
-];
+interface DayBar {
+  day: string;
+  pct: number;
+  isToday: boolean;
+}
 
-const AttendanceChart = ({
-  attendanceRate,
-}: {
-  attendanceRate: number;
-}) => {
-  // Replace Wednesday value with real rate if available
-  const bars = weekDays.map((d, i) =>
-    i === 3 && attendanceRate > 0 ? { ...d, pct: Math.round(attendanceRate) } : d
-  );
+const AttendanceChart = ({ bars }: { bars: DayBar[] }) => {
+  const hasData = bars.some((b) => b.pct > 0);
 
   return (
     <div className="bg-white rounded-2xl p-6 border border-gray-100 shadow-sm">
@@ -203,49 +188,50 @@ const AttendanceChart = ({
         <h2 className="text-base font-bold text-gray-900 tracking-tight border-l-2 border-green-600 pl-3">
           Attendance Analytics
         </h2>
-        <span className="text-xs text-gray-400">This week</span>
+        <span className="text-xs text-gray-400">Last 7 days</span>
       </div>
 
-      <div className="flex items-end justify-between gap-3 h-44">
-        {bars.map((d, i) => (
-          <div key={i} className="flex-1 flex flex-col items-center gap-2">
-            {/* Tooltip on highlighted bar */}
-            {d.highlight && (
-              <div className="bg-gray-800 text-white text-[10px] font-semibold px-2 py-0.5 rounded-md whitespace-nowrap">
-                {d.pct}%
-              </div>
-            )}
-            {/* Bar */}
-            <div className="w-full flex items-end justify-center">
-              {d.pct < 50
-                ? (
-                  /* Hatched bar for low / weekend */
+      {!hasData ? (
+        <div className="flex items-center justify-center h-44 text-sm text-gray-400">
+          No attendance recorded yet this week.
+        </div>
+      ) : (
+        <div className="flex items-end justify-between gap-3 h-44">
+          {bars.map((d, i) => (
+            <div key={i} className="flex-1 flex flex-col items-center gap-2">
+              {d.isToday && d.pct > 0 && (
+                <div className="bg-gray-800 text-white text-[10px] font-semibold px-2 py-0.5 rounded-md whitespace-nowrap">
+                  {d.pct}%
+                </div>
+              )}
+              <div className="w-full flex items-end justify-center">
+                {d.pct === 0 ? (
                   <div
                     className="w-full rounded-t-xl"
                     style={{
-                      height: `${Math.max((d.pct / 100) * 140, 10)}px`,
+                      height: "10px",
                       backgroundImage:
                         "repeating-linear-gradient(45deg,#d1d5db,#d1d5db 2px,transparent 2px,transparent 8px)",
                       backgroundColor: "#f3f4f6",
                     }}
                   />
-                )
-                : (
+                ) : (
                   <div
                     className="w-full rounded-t-xl"
                     style={{
-                      height: `${(d.pct / 100) * 140}px`,
-                      background: d.highlight
+                      height: `${Math.max((d.pct / 100) * 140, 10)}px`,
+                      background: d.isToday
                         ? "linear-gradient(180deg,#22c55e,#166534)"
                         : "linear-gradient(180deg,#16a34a,#14532d)",
                     }}
                   />
                 )}
+              </div>
+              <span className="text-xs text-gray-400 font-medium">{d.day}</span>
             </div>
-            <span className="text-xs text-gray-400 font-medium">{d.day}</span>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 };
@@ -261,7 +247,7 @@ const ProgressDonut = ({
   onTrackCount: number;
   atRiskCount: number;
 }) => {
-  const safePct = pct > 0 ? Math.min(Math.round(pct), 100) : 74;
+  const safePct = pct > 0 ? Math.min(Math.round(pct), 100) : 0;
   const circumference = 2 * Math.PI * 15.9155;
   const dash = (safePct / 100) * circumference;
   const gap = circumference - dash;
@@ -300,7 +286,9 @@ const ProgressDonut = ({
             />
           </svg>
           <div className="absolute inset-0 flex flex-col items-center justify-center">
-            <span className="text-2xl font-bold text-gray-900">{safePct}%</span>
+            <span className="text-2xl font-bold text-gray-900">
+              {safePct > 0 ? `${safePct}%` : "—"}
+            </span>
             <span className="text-[11px] text-gray-500">On Track</span>
           </div>
         </div>
@@ -391,7 +379,6 @@ const StaffRow = ({ staff, idx }: { staff: StaffRow; idx: number }) => {
 export const AdminDashboard = () => {
   const navigate = useNavigate();
   const { session } = useAuth();
-  const { toast } = useToast();
   // ── Data queries ────────────────────────────────────────────────────────────
 
   const { data: userMadrassahId } = useQuery<string | null>({
@@ -583,12 +570,50 @@ export const AdminDashboard = () => {
 
   const unmarkedToday = Math.max(0, studentCount - presentToday - absentToday);
 
-  const handleRemindTeachers = () => {
-    toast({
-      title: "Reminders sent",
-      description: "Teachers with unmarked students have been notified to confirm attendance.",
-    });
-  };
+  // ── Real last-7-days attendance bars ───────────────────────────────────────
+  const { data: weeklyBars = [] } = useQuery<DayBar[]>({
+    queryKey: ["admin-weekly-attendance", madrassahStudentIds.length],
+    queryFn: async () => {
+      if (madrassahStudentIds.length === 0) return [];
+      const today = new Date();
+      const dates: { iso: string; label: string; isToday: boolean }[] = [];
+      for (let i = 6; i >= 0; i--) {
+        const d = new Date(today);
+        d.setDate(today.getDate() - i);
+        dates.push({
+          iso: d.toISOString().split("T")[0],
+          label: ["S", "M", "T", "W", "T", "F", "S"][d.getDay()],
+          isToday: i === 0,
+        });
+      }
+      const start = dates[0].iso;
+      const end = dates[dates.length - 1].iso;
+      const { data } = await supabase
+        .from("attendance")
+        .select("date, status")
+        .gte("date", start)
+        .lte("date", end)
+        .in("student_id", madrassahStudentIds);
+      const byDate = new Map<string, { present: number; total: number }>();
+      for (const d of dates) byDate.set(d.iso, { present: 0, total: 0 });
+      for (const row of data ?? []) {
+        const bucket = byDate.get(row.date);
+        if (!bucket) continue;
+        bucket.total += 1;
+        if (row.status === "present") bucket.present += 1;
+      }
+      return dates.map((d) => {
+        const b = byDate.get(d.iso)!;
+        return {
+          day: d.label,
+          pct: b.total > 0 ? Math.round((b.present / b.total) * 100) : 0,
+          isToday: d.isToday,
+        };
+      });
+    },
+    enabled: madrassahStudentIds.length > 0,
+    staleTime: 5 * 60 * 1000,
+  });
 
   // ─────────────────────────────────────────────────────────────────────────
 
@@ -620,18 +645,10 @@ export const AdminDashboard = () => {
             <button
               type="button"
               onClick={() => navigate("/students")}
-              className="flex items-center gap-2 bg-white/20 hover:bg-white/30 text-sm font-semibold px-4 py-2.5 rounded-xl transition-colors"
-              style={{ color: "white" }}
-            >
-              <Plus className="h-4 w-4" style={{ color: "white" }} />
-              Add Student
-            </button>
-            <button
-              type="button"
-              onClick={() => navigate("/students")}
               className="flex items-center gap-2 bg-white hover:bg-gray-50 text-gray-800 text-sm font-semibold px-4 py-2.5 rounded-xl transition-colors"
             >
-              View All
+              <Plus className="h-4 w-4" />
+              Manage Students
             </button>
           </div>
         </div>
@@ -698,15 +715,6 @@ export const AdminDashboard = () => {
                     {unmarkedStudents.length} unmarked
                   </span>
                 )}
-              <button
-                type="button"
-                onClick={handleRemindTeachers}
-                disabled={unmarkedStudents.length === 0}
-                className="flex items-center gap-1.5 bg-amber-500 hover:bg-amber-600 disabled:opacity-40 disabled:cursor-not-allowed text-white text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors"
-              >
-                <Bell className="h-3.5 w-3.5" />
-                Remind Teachers
-              </button>
             </div>
           </div>
 
@@ -739,7 +747,7 @@ export const AdminDashboard = () => {
 
           {!isLoadingUnmarked && unmarkedStudents.length > 0 && (
             <p className="mt-3 text-xs text-gray-400">
-              Click a student's name to view parent contact info. Use "Remind Teachers" to notify staff by 9:15 am.
+              Click a student's name to view parent contact info.
             </p>
           )}
         </div>
@@ -809,7 +817,7 @@ export const AdminDashboard = () => {
         {/* ── Chart + Alerts ────────────────────────────────────────────────── */}
         <div className="grid grid-cols-1 lg:grid-cols-5 gap-5">
           <div className="lg:col-span-3">
-            <AttendanceChart attendanceRate={attendanceRate} />
+            <AttendanceChart bars={weeklyBars} />
           </div>
 
           {/* Alerts Panel */}
@@ -818,7 +826,7 @@ export const AdminDashboard = () => {
               <h2 className="text-base font-bold text-gray-900 tracking-tight border-l-2 border-green-600 pl-3">Alerts</h2>
               <button
                 type="button"
-                onClick={() => navigate("/dashboard?tab=performance")}
+                onClick={() => navigate("/admin/reports")}
                 className="text-xs text-green-700 hover:text-green-800 font-medium transition-colors"
               >
                 View all
@@ -843,8 +851,7 @@ export const AdminDashboard = () => {
                     </div>
                     <button
                       type="button"
-                      onClick={() =>
-                        navigate("/dashboard?tab=performance")}
+                      onClick={() => navigate("/admin/reports")}
                       className="mt-3 w-full bg-red-500 hover:bg-red-600 text-white text-xs font-semibold py-2 rounded-lg transition-colors flex items-center justify-center gap-2"
                     >
                       <TrendingUp className="h-3.5 w-3.5" />
@@ -900,7 +907,7 @@ export const AdminDashboard = () => {
               <h2 className="text-base font-bold text-gray-900 tracking-tight border-l-2 border-green-600 pl-3">Staff</h2>
               <button
                 type="button"
-                onClick={() => navigate("/dashboard?tab=students")}
+                onClick={() => navigate("/teachers")}
                 className="flex items-center gap-1.5 border border-gray-200 hover:bg-gray-50 text-gray-600 text-xs font-medium px-3 py-1.5 rounded-lg transition-colors"
               >
                 <Plus className="h-3 w-3" />
@@ -931,49 +938,6 @@ export const AdminDashboard = () => {
           </div>
         </div>
 
-        {/* ── Quick Navigation ──────────────────────────────────────────────── */}
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-          {[
-            {
-              label: "Students",
-              icon: <Users className="h-5 w-5" />,
-              href: "/students",
-              pill: "bg-blue-50 text-blue-700",
-            },
-            {
-              label: "Attendance",
-              icon: <ClipboardList className="h-5 w-5" />,
-              href: "/attendance",
-              pill: "bg-green-50 text-green-700",
-            },
-            {
-              label: "Classes",
-              icon: <BookOpen className="h-5 w-5" />,
-              href: "/classes",
-              pill: "bg-purple-50 text-purple-700",
-            },
-            {
-              label: "Analytics",
-              icon: <TrendingUp className="h-5 w-5" />,
-              href: "/dashboard?tab=performance",
-              pill: "bg-amber-50 text-amber-700",
-            },
-          ].map((item) => (
-            <button
-              key={item.label}
-              type="button"
-              onClick={() => navigate(item.href)}
-              className="bg-white rounded-2xl p-5 border border-gray-100 shadow-sm hover:shadow-md transition-shadow text-left flex items-center gap-3"
-            >
-              <div className={`p-2.5 rounded-xl ${item.pill}`}>
-                {item.icon}
-              </div>
-              <span className="text-sm font-semibold text-gray-800">
-                {item.label}
-              </span>
-            </button>
-          ))}
-        </div>
       </div>
     </div>
   );

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -2,7 +2,6 @@ import {
   Book,
   CalendarCheck,
   CalendarDays,
-  CalendarOff,
   CheckSquare,
   Clock,
   ClipboardList,
@@ -11,9 +10,9 @@ import {
   Library,
   MessageSquare,
   School,
+  Settings,
   Users,
   UserCheck,
-  Activity as ActivityIcon,
   Calendar,
 } from "lucide-react";
 import { NavItem } from "@/types/navigation.ts";
@@ -74,10 +73,10 @@ export const adminNavItems: NavItem[] = [
     description: "School events, holidays, and PD days",
   },
   {
-    href: "/admin/teacher-schedules",
-    label: "nav.teacherSchedules",
-    icon: CalendarDays,
-    description: "View teachers' weekly schedules",
+    href: "/admin/reports",
+    label: "nav.reports",
+    icon: FileText,
+    description: "Generate and export reports",
   },
 
   // ── Admin Tools ───────────────────────────────────────────────────────────
@@ -95,40 +94,10 @@ export const adminNavItems: NavItem[] = [
     description: "Manage parent accounts",
   },
   {
-    href: "/admin/bulk-student-import",
-    label: "nav.bulkStudentImport",
-    icon: Users,
-    description: "Upload CSV to add students",
-  },
-  {
-    href: "/absence-requests",
-    label: "nav.absenceRequests",
-    icon: CalendarOff,
-    description: "Review teacher absence requests",
-  },
-  {
-    href: "/activity",
-    label: "nav.activityFeed",
-    icon: ActivityIcon,
-    description: "Live app activity feed",
-  },
-  {
-    href: "/admin/communication-templates",
-    label: "nav.communicationTemplates",
-    icon: FileText,
-    description: "Manage message templates",
-  },
-  {
-    href: "/admin/reports",
-    label: "nav.reports",
-    icon: FileText,
-    description: "Generate and export reports",
-  },
-  {
-    href: "/admin/interviews",
-    label: "nav.interviews",
-    icon: CalendarCheck,
-    description: "Schedule parent-teacher interviews",
+    href: "/admin/panel",
+    label: "nav.adminPanel",
+    icon: Settings,
+    description: "Hub for templates, imports, activity log, interviews, schedules, absences",
   },
 ];
 

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -1,5 +1,6 @@
 import {
   Book,
+  CalendarCheck,
   CalendarDays,
   CalendarOff,
   CheckSquare,
@@ -123,6 +124,12 @@ export const adminNavItems: NavItem[] = [
     icon: FileText,
     description: "Generate and export reports",
   },
+  {
+    href: "/admin/interviews",
+    label: "nav.interviews",
+    icon: CalendarCheck,
+    description: "Schedule parent-teacher interviews",
+  },
 ];
 
 /**
@@ -221,5 +228,11 @@ export const parentNavItems: NavItem[] = [
     label: "nav.messages",
     icon: MessageSquare,
     description: "Message your child's teacher",
+  },
+  {
+    href: "/parent/interviews",
+    label: "nav.interviews",
+    icon: CalendarCheck,
+    description: "Book parent-teacher interviews",
   },
 ];

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -38,6 +38,7 @@ const en: Dict = {
     communicationTemplates: "Templates",
     reports: "Reports",
     interviews: "Interviews",
+    adminPanel: "Admin Panel",
   },
   portal: {
     admin: "Admin Portal",
@@ -756,6 +757,7 @@ const fr: Dict = {
     communicationTemplates: "Modèles",
     reports: "Rapports",
     interviews: "Entretiens",
+    adminPanel: "Panneau Admin",
   },
   portal: {
     admin: "Portail Admin",

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -37,6 +37,7 @@ const en: Dict = {
     profile: "Profile",
     communicationTemplates: "Templates",
     reports: "Reports",
+    interviews: "Interviews",
   },
   portal: {
     admin: "Admin Portal",
@@ -754,6 +755,7 @@ const fr: Dict = {
     profile: "Profil",
     communicationTemplates: "Modèles",
     reports: "Rapports",
+    interviews: "Entretiens",
   },
   portal: {
     admin: "Portail Admin",

--- a/src/pages/ParentInterviews.tsx
+++ b/src/pages/ParentInterviews.tsx
@@ -1,0 +1,421 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { format, parseISO, isAfter } from "date-fns";
+import {
+  CalendarDays,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  User,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+import { supabase } from "@/integrations/supabase/client.ts";
+import { useAuth } from "@/hooks/use-auth.ts";
+import { useParentChildren } from "@/hooks/useParentChildren.ts";
+import { Button } from "@/components/ui/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select.tsx";
+import { Textarea } from "@/components/ui/textarea.tsx";
+import { Label } from "@/components/ui/label.tsx";
+import { useToast } from "@/hooks/use-toast.ts";
+import { cn } from "@/lib/utils.ts";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface InterviewWindow {
+  id: string;
+  title: string;
+  description: string | null;
+  start_date: string;
+  end_date: string;
+  slot_duration_minutes: number;
+}
+
+interface SlotWithTeacher {
+  id: string;
+  window_id: string;
+  teacher_id: string;
+  slot_date: string;
+  slot_time: string;
+  duration_minutes: number;
+  teacher: { name: string } | null;
+  booked: boolean;
+  myBookingId?: string;
+  myBookingStatus?: string;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function fmtTime(t: string) {
+  const [h, m] = t.split(":");
+  const dt = new Date();
+  dt.setHours(Number(h), Number(m), 0);
+  return format(dt, "h:mm a");
+}
+
+// ── Main page ──────────────────────────────────────────────────────────────────
+
+export default function ParentInterviews() {
+  const { session } = useAuth();
+  const parentId = session?.user?.id;
+  const { children } = useParentChildren();
+  const { toast } = useToast();
+  const qc = useQueryClient();
+
+  const [bookingSlot, setBookingSlot] = useState<SlotWithTeacher | null>(null);
+  const [selectedChildId, setSelectedChildId] = useState("");
+  const [notes, setNotes] = useState("");
+  const [expandedWindows, setExpandedWindows] = useState<Set<string>>(new Set());
+
+  // ── Queries ──────────────────────────────────────────────────────────────────
+
+  const { data: windows = [], isLoading: loadingWindows } = useQuery<InterviewWindow[]>({
+    queryKey: ["parent-interview-windows"],
+    queryFn: async () => {
+      const today = new Date().toISOString().split("T")[0];
+      const { data, error } = await (supabase as any)
+        .from("interview_windows")
+        .select("*")
+        .gte("end_date", today)
+        .order("start_date");
+      if (error) throw error;
+      return data ?? [];
+    },
+  });
+
+  const { data: slots = [], isLoading: loadingSlots } = useQuery<SlotWithTeacher[]>({
+    queryKey: ["parent-interview-slots", parentId],
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("interview_slots")
+        .select(`
+          *,
+          teacher:profiles!interview_slots_teacher_id_fkey(name),
+          bookings:interview_bookings(id, parent_id, status)
+        `)
+        .order("slot_date")
+        .order("slot_time");
+      if (error) throw error;
+      return (data ?? []).map((s: any) => {
+        const myBooking = (s.bookings ?? []).find((b: any) => b.parent_id === parentId && b.status === "confirmed");
+        const anyConfirmed = (s.bookings ?? []).some((b: any) => b.status === "confirmed");
+        return {
+          id: s.id,
+          window_id: s.window_id,
+          teacher_id: s.teacher_id,
+          slot_date: s.slot_date,
+          slot_time: s.slot_time,
+          duration_minutes: s.duration_minutes,
+          teacher: s.teacher,
+          booked: anyConfirmed,
+          myBookingId: myBooking?.id,
+          myBookingStatus: myBooking?.status,
+        };
+      });
+    },
+    enabled: !!parentId,
+  });
+
+  // ── Book slot ─────────────────────────────────────────────────────────────────
+
+  const bookSlot = useMutation({
+    mutationFn: async ({ slotId, studentId, noteText }: { slotId: string; studentId: string; noteText: string }) => {
+      const { error } = await (supabase as any).from("interview_bookings").insert({
+        slot_id: slotId,
+        student_id: studentId,
+        parent_id: parentId,
+        notes: noteText || null,
+        status: "confirmed",
+      });
+      if (error) throw error;
+
+      // Fire confirmation email (best-effort)
+      try {
+        await supabase.functions.invoke("send-interview-confirmation", {
+          body: { slot_id: slotId, student_id: studentId, parent_id: parentId },
+        });
+      } catch (_) { /* non-critical */ }
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["parent-interview-slots"] });
+      setBookingSlot(null);
+      setSelectedChildId("");
+      setNotes("");
+      toast({ title: "Interview booked!", description: "You'll receive a confirmation email." });
+    },
+    onError: (err: any) => {
+      toast({ title: "Booking failed", description: err?.message ?? "Please try again.", variant: "destructive" });
+    },
+  });
+
+  // ── Cancel booking ────────────────────────────────────────────────────────────
+
+  const cancelBooking = useMutation({
+    mutationFn: async (bookingId: string) => {
+      const { error } = await (supabase as any)
+        .from("interview_bookings")
+        .update({ status: "cancelled" })
+        .eq("id", bookingId);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["parent-interview-slots"] });
+      toast({ title: "Booking cancelled" });
+    },
+    onError: () => toast({ title: "Failed to cancel", variant: "destructive" }),
+  });
+
+  // ── My booked slots ───────────────────────────────────────────────────────────
+
+  const myBookings = slots.filter((s) => !!s.myBookingId);
+
+  // ── Grouped slots per window ──────────────────────────────────────────────────
+
+  const toggleWindow = (id: string) => {
+    setExpandedWindows((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  if (loadingWindows || loadingSlots) {
+    return (
+      <div className="flex justify-center py-20">
+        <Loader2 className="w-6 h-6 animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <div className="w-10 h-10 rounded-xl bg-green-50 flex items-center justify-center">
+          <CalendarDays className="w-5 h-5 text-green-700" />
+        </div>
+        <div>
+          <h1 className="text-xl font-bold text-gray-900">Parent-Teacher Interviews</h1>
+          <p className="text-sm text-gray-500">Book a time to meet your child's teacher</p>
+        </div>
+      </div>
+
+      {/* My bookings */}
+      {myBookings.length > 0 && (
+        <div className="bg-green-50 border border-green-200 rounded-2xl p-4 space-y-2">
+          <p className="text-sm font-semibold text-green-800 mb-3 flex items-center gap-1.5">
+            <CheckCircle2 className="w-4 h-4" /> Your Booked Interviews
+          </p>
+          {myBookings.map((s) => (
+            <div key={s.id} className="flex items-center justify-between bg-white rounded-xl px-4 py-3 shadow-sm">
+              <div>
+                <p className="text-sm font-medium text-gray-800">{s.teacher?.name}</p>
+                <p className="text-xs text-gray-500">{format(parseISO(s.slot_date), "EEEE, MMMM d")} · {fmtTime(s.slot_time)}</p>
+              </div>
+              <button
+                onClick={() => cancelBooking.mutate(s.myBookingId!)}
+                className="text-xs text-red-500 hover:underline"
+                disabled={cancelBooking.isPending}
+              >
+                Cancel
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Available windows */}
+      {windows.length === 0 ? (
+        <div className="text-center py-16 text-gray-400">
+          <CalendarDays className="w-12 h-12 mx-auto mb-3 opacity-25" />
+          <p className="text-sm font-medium">No interview sessions open right now.</p>
+          <p className="text-xs mt-1">Check back when the school opens a booking window.</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {windows.map((w) => {
+            const windowSlots = slots.filter((s) => s.window_id === w.id);
+            const isExpanded = expandedWindows.has(w.id);
+
+            // Group by teacher
+            const byTeacher: Record<string, SlotWithTeacher[]> = {};
+            for (const s of windowSlots) {
+              const tName = s.teacher?.name ?? s.teacher_id;
+              if (!byTeacher[tName]) byTeacher[tName] = [];
+              byTeacher[tName].push(s);
+            }
+
+            const availableCount = windowSlots.filter((s) => !s.booked).length;
+
+            return (
+              <div key={w.id} className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden">
+                {/* Window header */}
+                <button
+                  className="w-full text-left px-5 py-4 flex items-start justify-between gap-3 hover:bg-gray-50/50 transition-colors"
+                  onClick={() => toggleWindow(w.id)}
+                >
+                  <div>
+                    <h2 className="font-semibold text-gray-900">{w.title}</h2>
+                    {w.description && <p className="text-sm text-gray-500 mt-0.5">{w.description}</p>}
+                    <div className="flex flex-wrap gap-3 mt-2 text-xs text-gray-400">
+                      <span className="flex items-center gap-1">
+                        <CalendarDays className="w-3 h-3" />
+                        {format(parseISO(w.start_date), "MMM d")} – {format(parseISO(w.end_date), "MMM d, yyyy")}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <Clock className="w-3 h-3" />
+                        {w.slot_duration_minutes} min
+                      </span>
+                      <span className={cn("font-medium", availableCount > 0 ? "text-green-600" : "text-gray-400")}>
+                        {availableCount} slot{availableCount !== 1 ? "s" : ""} available
+                      </span>
+                    </div>
+                  </div>
+                  {isExpanded
+                    ? <ChevronUp className="w-4 h-4 text-gray-400 mt-1 shrink-0" />
+                    : <ChevronDown className="w-4 h-4 text-gray-400 mt-1 shrink-0" />}
+                </button>
+
+                {/* Slots grouped by teacher */}
+                {isExpanded && (
+                  <div className="border-t border-gray-100 divide-y divide-gray-50">
+                    {Object.keys(byTeacher).length === 0 ? (
+                      <p className="text-sm text-gray-400 px-5 py-4">No slots available for this window yet.</p>
+                    ) : (
+                      Object.entries(byTeacher).map(([teacherName, tSlots]) => {
+                        // Group by date
+                        const byDate: Record<string, SlotWithTeacher[]> = {};
+                        for (const s of tSlots) {
+                          if (!byDate[s.slot_date]) byDate[s.slot_date] = [];
+                          byDate[s.slot_date].push(s);
+                        }
+                        return (
+                          <div key={teacherName} className="px-5 py-4">
+                            <p className="text-sm font-semibold text-gray-700 flex items-center gap-1.5 mb-3">
+                              <User className="w-3.5 h-3.5 text-gray-400" />
+                              {teacherName}
+                            </p>
+                            {Object.entries(byDate).sort().map(([date, dateSlots]) => (
+                              <div key={date} className="mb-3 last:mb-0">
+                                <p className="text-xs text-gray-400 mb-2">{format(parseISO(date), "EEEE, MMMM d")}</p>
+                                <div className="flex flex-wrap gap-2">
+                                  {dateSlots.map((s) => {
+                                    const isMyBooking = !!s.myBookingId;
+                                    return (
+                                      <button
+                                        key={s.id}
+                                        disabled={s.booked && !isMyBooking}
+                                        onClick={() => {
+                                          if (!isMyBooking && !s.booked) {
+                                            setBookingSlot(s);
+                                            if (children.length === 1) setSelectedChildId(children[0].id);
+                                          }
+                                        }}
+                                        className={cn(
+                                          "text-xs font-medium px-3 py-1.5 rounded-full border transition-colors",
+                                          isMyBooking
+                                            ? "bg-green-100 border-green-300 text-green-700 cursor-default"
+                                            : s.booked
+                                              ? "bg-gray-50 border-gray-200 text-gray-300 cursor-not-allowed"
+                                              : "bg-white border-gray-200 text-gray-700 hover:border-green-400 hover:text-green-700 hover:bg-green-50",
+                                        )}
+                                      >
+                                        {isMyBooking && <CheckCircle2 className="w-3 h-3 inline mr-1" />}
+                                        {s.booked && !isMyBooking && <XCircle className="w-3 h-3 inline mr-1" />}
+                                        {fmtTime(s.slot_time)}
+                                      </button>
+                                    );
+                                  })}
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        );
+                      })
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Booking dialog */}
+      <Dialog open={!!bookingSlot} onOpenChange={(o) => { if (!o) { setBookingSlot(null); setSelectedChildId(""); setNotes(""); } }}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Confirm Interview</DialogTitle>
+            <DialogDescription>
+              {bookingSlot && (
+                <>
+                  <span className="font-medium">{bookingSlot.teacher?.name}</span>
+                  {" · "}
+                  {format(parseISO(bookingSlot.slot_date), "EEEE, MMMM d")}
+                  {" at "}
+                  {fmtTime(bookingSlot.slot_time)}
+                </>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 pt-1">
+            {children.length > 1 && (
+              <div>
+                <Label>Which child is this interview for? *</Label>
+                <Select value={selectedChildId} onValueChange={setSelectedChildId}>
+                  <SelectTrigger className="mt-1">
+                    <SelectValue placeholder="Select a child" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {children.map((c) => (
+                      <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            <div>
+              <Label>Notes for the teacher (optional)</Label>
+              <Textarea
+                className="mt-1"
+                rows={2}
+                placeholder="Any topics you'd like to discuss…"
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+              />
+            </div>
+            <div className="flex gap-2 justify-end">
+              <Button variant="outline" size="sm" onClick={() => { setBookingSlot(null); setSelectedChildId(""); setNotes(""); }}>
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                className="bg-green-700 hover:bg-green-800 text-white"
+                disabled={!selectedChildId || bookSlot.isPending}
+                onClick={() => bookSlot.mutate({ slotId: bookingSlot!.id, studentId: selectedChildId, noteText: notes })}
+              >
+                {bookSlot.isPending && <Loader2 className="w-3.5 h-3.5 animate-spin mr-1.5" />}
+                Book Interview
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminLayout.tsx
+++ b/src/pages/admin/AdminLayout.tsx
@@ -7,7 +7,6 @@ import {
   Users,
   Home,
   LogOut,
-  Calendar,
   Settings,
   Menu,
   X,
@@ -30,11 +29,12 @@ const AdminLayout = () => {
     }
   };
 
+  // Dev-mode admin pages only. Day-to-day admin tools live in /admin/panel
+  // (consolidated tabbed hub) reachable from the main sidebar.
   const navItems = [
     { to: '/admin/setup', icon: UserPlus, label: 'Setup Admin' },
     { to: '/admin/roles', icon: Shield, label: 'Manual Role Setup' },
     { to: '/admin/seeder', icon: Database, label: 'Database Seeder' },
-    { to: '/admin/teacher-schedules', icon: Calendar, label: 'Teacher Schedules' },
     { to: '/admin/admin-creator', icon: Users, label: 'Admin Creator' },
     { to: '/admin/parent-accounts', icon: Users, label: 'Parent Accounts' },
     { to: '/settings', icon: Settings, label: 'Settings & Emails' },

--- a/src/pages/admin/AdminPanel.tsx
+++ b/src/pages/admin/AdminPanel.tsx
@@ -1,0 +1,84 @@
+/**
+ * AdminPanel — consolidated tabbed hub for low-frequency admin tools.
+ * Replaces 6 sidebar entries with one entry. Each tab renders an existing
+ * admin page directly; deep-linkable via ?tab= query param.
+ */
+import { useSearchParams } from "react-router-dom";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs.tsx";
+import {
+  Upload,
+  FileText,
+  Activity as ActivityIcon,
+  CalendarCheck,
+  CalendarDays,
+  CalendarOff,
+} from "lucide-react";
+import BulkStudentImport from "@/pages/admin/BulkStudentImport.tsx";
+import CommunicationTemplates from "@/pages/admin/CommunicationTemplates.tsx";
+import Activity from "@/pages/admin/Activity.tsx";
+import Interviews from "@/pages/admin/Interviews.tsx";
+import TeacherSchedules from "@/pages/admin/TeacherSchedules.tsx";
+import AbsenceRequests from "@/pages/AbsenceRequests.tsx";
+
+const TABS = [
+  { id: "bulk-import", label: "Bulk Import", icon: Upload, body: BulkStudentImport },
+  { id: "templates", label: "Templates", icon: FileText, body: CommunicationTemplates },
+  { id: "activity", label: "Activity Log", icon: ActivityIcon, body: Activity },
+  { id: "interviews", label: "Interviews", icon: CalendarCheck, body: Interviews },
+  { id: "schedules", label: "Teacher Schedules", icon: CalendarDays, body: TeacherSchedules },
+  { id: "absences", label: "Absence Requests", icon: CalendarOff, body: AbsenceRequests },
+] as const;
+
+const VALID_IDS = TABS.map((t) => t.id);
+
+export default function AdminPanel() {
+  const [params, setParams] = useSearchParams();
+  const requested = params.get("tab");
+  const active = requested && VALID_IDS.includes(requested as typeof VALID_IDS[number])
+    ? requested
+    : "bulk-import";
+
+  const setActive = (next: string) => {
+    setParams({ tab: next }, { replace: true });
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f5f6fa]">
+      {/* Hub header strip */}
+      <div className="bg-white border-b border-gray-100 px-6 sm:px-8 py-5">
+        <div className="max-w-7xl mx-auto">
+          <h1 className="text-xl font-bold text-gray-900 tracking-tight">Admin Panel</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Hub for less-frequent admin tools. Daily workflows live in the main sidebar.
+          </p>
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        <Tabs value={active} onValueChange={setActive}>
+          <TabsList className="bg-white border border-gray-100 rounded-xl p-1 mb-6 flex flex-wrap gap-1 h-auto">
+            {TABS.map((t) => (
+              <TabsTrigger
+                key={t.id}
+                value={t.id}
+                className="flex items-center gap-2 px-4 py-2 text-sm font-medium data-[state=active]:bg-green-50 data-[state=active]:text-green-900 data-[state=active]:shadow-sm rounded-lg"
+              >
+                <t.icon className="h-4 w-4" />
+                {t.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+
+          {TABS.map((t) => {
+            const Body = t.body;
+            return (
+              <TabsContent key={t.id} value={t.id} className="mt-0">
+                <Body />
+              </TabsContent>
+            );
+          })}
+        </Tabs>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/Interviews.tsx
+++ b/src/pages/admin/Interviews.tsx
@@ -1,0 +1,682 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { format, addMinutes, parseISO, isAfter } from "date-fns";
+import {
+  CalendarDays,
+  Plus,
+  Loader2,
+  Trash2,
+  Users,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
+} from "lucide-react";
+import { supabase } from "@/integrations/supabase/client.ts";
+import { useAuth } from "@/hooks/use-auth.ts";
+import { AdminPageShell } from "@/components/admin/AdminPageShell.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import { Input } from "@/components/ui/input.tsx";
+import { Label } from "@/components/ui/label.tsx";
+import { Textarea } from "@/components/ui/textarea.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select.tsx";
+import { useToast } from "@/hooks/use-toast.ts";
+import { cn } from "@/lib/utils.ts";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface InterviewWindow {
+  id: string;
+  title: string;
+  description: string | null;
+  start_date: string;
+  end_date: string;
+  slot_duration_minutes: number;
+  created_at: string;
+}
+
+interface InterviewSlot {
+  id: string;
+  window_id: string;
+  teacher_id: string;
+  slot_date: string;
+  slot_time: string;
+  duration_minutes: number;
+  teacher?: { name: string };
+  window?: { title: string };
+  booking?: { id: string; status: string; student?: { name: string }; parent?: { name: string } } | null;
+}
+
+interface Teacher {
+  id: string;
+  name: string;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function statusChip(status: string) {
+  if (status === "confirmed") return <span className="inline-flex items-center gap-1 text-xs font-medium text-green-700 bg-green-50 border border-green-200 rounded-full px-2 py-0.5"><CheckCircle2 className="w-3 h-3" />Confirmed</span>;
+  if (status === "cancelled") return <span className="inline-flex items-center gap-1 text-xs font-medium text-red-700 bg-red-50 border border-red-200 rounded-full px-2 py-0.5"><XCircle className="w-3 h-3" />Cancelled</span>;
+  return <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-full px-2 py-0.5"><AlertCircle className="w-3 h-3" />No-show</span>;
+}
+
+function fmtTime(t: string) {
+  const [h, m] = t.split(":");
+  const dt = new Date();
+  dt.setHours(Number(h), Number(m), 0);
+  return format(dt, "h:mm a");
+}
+
+// ── Tabs ───────────────────────────────────────────────────────────────────────
+
+type Tab = "windows" | "slots" | "bookings";
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: "windows", label: "Interview Windows" },
+  { id: "slots", label: "Manage Slots" },
+  { id: "bookings", label: "Bookings" },
+];
+
+// ── Main page ──────────────────────────────────────────────────────────────────
+
+export default function Interviews() {
+  const [tab, setTab] = useState<Tab>("windows");
+  const [windowDialogOpen, setWindowDialogOpen] = useState(false);
+  const [slotDialogOpen, setSlotDialogOpen] = useState(false);
+  const { session } = useAuth();
+  const { toast } = useToast();
+  const qc = useQueryClient();
+
+  // ── Queries ──────────────────────────────────────────────────────────────────
+
+  const { data: windows = [], isLoading: loadingWindows } = useQuery<InterviewWindow[]>({
+    queryKey: ["interview-windows"],
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("interview_windows")
+        .select("*")
+        .order("start_date");
+      if (error) throw error;
+      return data ?? [];
+    },
+  });
+
+  const { data: slots = [], isLoading: loadingSlots } = useQuery<InterviewSlot[]>({
+    queryKey: ["interview-slots"],
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("interview_slots")
+        .select(`
+          *,
+          teacher:profiles!interview_slots_teacher_id_fkey(name),
+          window:interview_windows!interview_slots_window_id_fkey(title),
+          booking:interview_bookings(id, status, student:students(name), parent:profiles!interview_bookings_parent_id_fkey(name))
+        `)
+        .order("slot_date")
+        .order("slot_time");
+      if (error) throw error;
+      return (data ?? []).map((s: any) => ({
+        ...s,
+        booking: s.booking?.[0] ?? null,
+      }));
+    },
+  });
+
+  const { data: teachers = [] } = useQuery<Teacher[]>({
+    queryKey: ["teachers-list"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("profiles")
+        .select("id, name")
+        .eq("role", "teacher")
+        .order("name");
+      if (error) throw error;
+      return data ?? [];
+    },
+  });
+
+  // ── Delete slot ───────────────────────────────────────────────────────────────
+
+  const deleteSlot = useMutation({
+    mutationFn: async (slotId: string) => {
+      const { error } = await (supabase as any).from("interview_slots").delete().eq("id", slotId);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["interview-slots"] });
+      toast({ title: "Slot deleted" });
+    },
+    onError: () => toast({ title: "Failed to delete slot", variant: "destructive" }),
+  });
+
+  // ── Delete window ─────────────────────────────────────────────────────────────
+
+  const deleteWindow = useMutation({
+    mutationFn: async (windowId: string) => {
+      const { error } = await (supabase as any).from("interview_windows").delete().eq("id", windowId);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["interview-windows"] });
+      qc.invalidateQueries({ queryKey: ["interview-slots"] });
+      toast({ title: "Window deleted" });
+    },
+    onError: () => toast({ title: "Failed to delete window", variant: "destructive" }),
+  });
+
+  // ── Update booking status ─────────────────────────────────────────────────────
+
+  const updateBooking = useMutation({
+    mutationFn: async ({ id, status }: { id: string; status: string }) => {
+      const { error } = await (supabase as any).from("interview_bookings").update({ status }).eq("id", id);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["interview-slots"] });
+      toast({ title: "Booking updated" });
+    },
+    onError: () => toast({ title: "Failed to update booking", variant: "destructive" }),
+  });
+
+  const bookedSlots = slots.filter((s) => s.booking && s.booking.status === "confirmed");
+
+  return (
+    <AdminPageShell
+      title="Interviews"
+      subtitle="Schedule and manage parent-teacher interviews"
+      icon={<CalendarDays className="w-5 h-5 text-green-700" />}
+      iconBg="bg-green-50"
+    >
+      {/* Pill tabs */}
+      <div className="flex gap-2 mb-6">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            className={cn(
+              "px-4 py-1.5 rounded-full text-sm font-medium transition-colors",
+              tab === t.id
+                ? "bg-green-700 text-white"
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200",
+            )}
+          >
+            {t.label}
+            {t.id === "bookings" && bookedSlots.length > 0 && (
+              <span className="ml-1.5 bg-white/30 text-inherit text-xs rounded-full px-1.5 py-0.5">
+                {bookedSlots.length}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* ── Windows tab ─────────────────────────────────────────────────────── */}
+      {tab === "windows" && (
+        <div className="space-y-4">
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              className="gap-1.5 bg-green-700 hover:bg-green-800 text-white"
+              onClick={() => setWindowDialogOpen(true)}
+            >
+              <Plus className="w-3.5 h-3.5" /> New Window
+            </Button>
+          </div>
+
+          {loadingWindows ? (
+            <div className="flex justify-center py-12"><Loader2 className="w-5 h-5 animate-spin text-gray-400" /></div>
+          ) : windows.length === 0 ? (
+            <div className="text-center py-16 text-gray-400">
+              <CalendarDays className="w-10 h-10 mx-auto mb-3 opacity-30" />
+              <p className="text-sm">No interview windows yet.</p>
+              <p className="text-xs mt-1">Create a window to define when interviews take place.</p>
+            </div>
+          ) : (
+            <div className="grid gap-3">
+              {windows.map((w) => {
+                const slotCount = slots.filter((s) => s.window_id === w.id).length;
+                const isActive = !isAfter(new Date(), parseISO(w.end_date + "T23:59:59"));
+                return (
+                  <div key={w.id} className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <div className="flex items-center gap-2 mb-1">
+                          <h3 className="font-semibold text-gray-900">{w.title}</h3>
+                          <span className={cn("text-xs font-medium rounded-full px-2 py-0.5", isActive ? "bg-green-50 text-green-700 border border-green-200" : "bg-gray-100 text-gray-500")}>
+                            {isActive ? "Active" : "Past"}
+                          </span>
+                        </div>
+                        {w.description && <p className="text-sm text-gray-500 mb-2">{w.description}</p>}
+                        <div className="flex flex-wrap gap-3 text-xs text-gray-500">
+                          <span className="flex items-center gap-1"><CalendarDays className="w-3 h-3" />{format(parseISO(w.start_date), "MMM d")} – {format(parseISO(w.end_date), "MMM d, yyyy")}</span>
+                          <span className="flex items-center gap-1"><Clock className="w-3 h-3" />{w.slot_duration_minutes} min slots</span>
+                          <span className="flex items-center gap-1"><Users className="w-3 h-3" />{slotCount} slot{slotCount !== 1 ? "s" : ""}</span>
+                        </div>
+                      </div>
+                      <button
+                        onClick={() => deleteWindow.mutate(w.id)}
+                        className="text-gray-400 hover:text-red-500 transition-colors p-1"
+                        title="Delete window"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Slots tab ───────────────────────────────────────────────────────── */}
+      {tab === "slots" && (
+        <div className="space-y-4">
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              className="gap-1.5 bg-green-700 hover:bg-green-800 text-white"
+              onClick={() => setSlotDialogOpen(true)}
+              disabled={windows.length === 0}
+            >
+              <Plus className="w-3.5 h-3.5" /> Generate Slots
+            </Button>
+          </div>
+
+          {windows.length === 0 && (
+            <p className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-xl px-4 py-3">
+              Create an interview window first before generating slots.
+            </p>
+          )}
+
+          {loadingSlots ? (
+            <div className="flex justify-center py-12"><Loader2 className="w-5 h-5 animate-spin text-gray-400" /></div>
+          ) : slots.length === 0 ? (
+            <div className="text-center py-16 text-gray-400">
+              <Clock className="w-10 h-10 mx-auto mb-3 opacity-30" />
+              <p className="text-sm">No slots generated yet.</p>
+            </div>
+          ) : (
+            <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-100 bg-gray-50">
+                    <th className="text-left px-4 py-3 font-medium text-gray-500 text-xs uppercase tracking-wide">Window</th>
+                    <th className="text-left px-4 py-3 font-medium text-gray-500 text-xs uppercase tracking-wide">Teacher</th>
+                    <th className="text-left px-4 py-3 font-medium text-gray-500 text-xs uppercase tracking-wide">Date</th>
+                    <th className="text-left px-4 py-3 font-medium text-gray-500 text-xs uppercase tracking-wide">Time</th>
+                    <th className="text-left px-4 py-3 font-medium text-gray-500 text-xs uppercase tracking-wide">Status</th>
+                    <th className="px-4 py-3" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {slots.map((s) => (
+                    <tr key={s.id} className="border-b border-gray-50 last:border-0 hover:bg-gray-50/50">
+                      <td className="px-4 py-3 text-gray-700 text-xs">{(s.window as any)?.title ?? "—"}</td>
+                      <td className="px-4 py-3 font-medium text-gray-800">{(s.teacher as any)?.name ?? "—"}</td>
+                      <td className="px-4 py-3 text-gray-600">{format(parseISO(s.slot_date), "EEE, MMM d")}</td>
+                      <td className="px-4 py-3 text-gray-600">{fmtTime(s.slot_time)}</td>
+                      <td className="px-4 py-3">
+                        {s.booking
+                          ? statusChip(s.booking.status)
+                          : <span className="text-xs text-gray-400">Available</span>}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        {!s.booking && (
+                          <button
+                            onClick={() => deleteSlot.mutate(s.id)}
+                            className="text-gray-300 hover:text-red-500 transition-colors"
+                          >
+                            <Trash2 className="w-3.5 h-3.5" />
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Bookings tab ────────────────────────────────────────────────────── */}
+      {tab === "bookings" && (
+        <div className="space-y-4">
+          {bookedSlots.length === 0 ? (
+            <div className="text-center py-16 text-gray-400">
+              <CheckCircle2 className="w-10 h-10 mx-auto mb-3 opacity-30" />
+              <p className="text-sm">No confirmed bookings yet.</p>
+            </div>
+          ) : (
+            <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-100 bg-gray-50">
+                    <th className="text-left px-4 py-3 font-medium text-gray-500 text-xs uppercase tracking-wide">Date & Time</th>
+                    <th className="text-left px-4 py-3 font-medium text-gray-500 text-xs uppercase tracking-wide">Teacher</th>
+                    <th className="text-left px-4 py-3 font-medium text-gray-500 text-xs uppercase tracking-wide">Student</th>
+                    <th className="text-left px-4 py-3 font-medium text-gray-500 text-xs uppercase tracking-wide">Parent</th>
+                    <th className="text-left px-4 py-3 font-medium text-gray-500 text-xs uppercase tracking-wide">Status</th>
+                    <th className="px-4 py-3" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {slots.filter((s) => !!s.booking).map((s) => (
+                    <tr key={s.id} className="border-b border-gray-50 last:border-0 hover:bg-gray-50/50">
+                      <td className="px-4 py-3 text-gray-700">
+                        <div className="font-medium">{format(parseISO(s.slot_date), "EEE, MMM d")}</div>
+                        <div className="text-xs text-gray-400">{fmtTime(s.slot_time)}</div>
+                      </td>
+                      <td className="px-4 py-3 text-gray-700">{(s.teacher as any)?.name ?? "—"}</td>
+                      <td className="px-4 py-3 font-medium text-gray-800">{(s.booking as any)?.student?.name ?? "—"}</td>
+                      <td className="px-4 py-3 text-gray-600">{(s.booking as any)?.parent?.name ?? "—"}</td>
+                      <td className="px-4 py-3">{statusChip(s.booking!.status)}</td>
+                      <td className="px-4 py-3">
+                        <div className="flex gap-1 justify-end">
+                          {s.booking!.status === "confirmed" && (
+                            <button
+                              onClick={() => updateBooking.mutate({ id: s.booking!.id, status: "cancelled" })}
+                              className="text-xs text-red-500 hover:underline"
+                            >
+                              Cancel
+                            </button>
+                          )}
+                          {s.booking!.status === "confirmed" && (
+                            <button
+                              onClick={() => updateBooking.mutate({ id: s.booking!.id, status: "no_show" })}
+                              className="text-xs text-amber-600 hover:underline ml-2"
+                            >
+                              No-show
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Create Window dialog ─────────────────────────────────────────────── */}
+      <CreateWindowDialog
+        open={windowDialogOpen}
+        onClose={() => setWindowDialogOpen(false)}
+        userId={session?.user?.id ?? ""}
+        onCreated={() => {
+          qc.invalidateQueries({ queryKey: ["interview-windows"] });
+          setWindowDialogOpen(false);
+          toast({ title: "Interview window created" });
+        }}
+      />
+
+      {/* ── Generate Slots dialog ────────────────────────────────────────────── */}
+      <GenerateSlotsDialog
+        open={slotDialogOpen}
+        onClose={() => setSlotDialogOpen(false)}
+        windows={windows}
+        teachers={teachers}
+        onCreated={() => {
+          qc.invalidateQueries({ queryKey: ["interview-slots"] });
+          setSlotDialogOpen(false);
+          toast({ title: "Slots generated" });
+        }}
+      />
+    </AdminPageShell>
+  );
+}
+
+// ── Create Window Dialog ───────────────────────────────────────────────────────
+
+function CreateWindowDialog({
+  open,
+  onClose,
+  userId,
+  onCreated,
+}: {
+  open: boolean;
+  onClose: () => void;
+  userId: string;
+  onCreated: () => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [duration, setDuration] = useState("15");
+  const [saving, setSaving] = useState(false);
+  const { toast } = useToast();
+
+  const reset = () => {
+    setTitle(""); setDescription(""); setStartDate(""); setEndDate(""); setDuration("15");
+  };
+
+  const handleSubmit = async () => {
+    if (!title || !startDate || !endDate) {
+      toast({ title: "Fill in all required fields", variant: "destructive" });
+      return;
+    }
+    setSaving(true);
+    const { error } = await (supabase as any).from("interview_windows").insert({
+      title,
+      description: description || null,
+      start_date: startDate,
+      end_date: endDate,
+      slot_duration_minutes: Number(duration),
+      created_by: userId || null,
+    });
+    setSaving(false);
+    if (error) {
+      toast({ title: "Failed to create window", description: error.message, variant: "destructive" });
+    } else {
+      reset();
+      onCreated();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) { reset(); onClose(); } }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Create Interview Window</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 pt-2">
+          <div>
+            <Label>Title *</Label>
+            <Input className="mt-1" placeholder="e.g. Term 1 Parent-Teacher Interviews" value={title} onChange={(e) => setTitle(e.target.value)} />
+          </div>
+          <div>
+            <Label>Description</Label>
+            <Textarea className="mt-1" rows={2} placeholder="Optional notes for parents" value={description} onChange={(e) => setDescription(e.target.value)} />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <Label>Start Date *</Label>
+              <Input className="mt-1" type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} />
+            </div>
+            <div>
+              <Label>End Date *</Label>
+              <Input className="mt-1" type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} />
+            </div>
+          </div>
+          <div>
+            <Label>Slot Duration</Label>
+            <Select value={duration} onValueChange={setDuration}>
+              <SelectTrigger className="mt-1">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {["10", "15", "20", "30"].map((d) => (
+                  <SelectItem key={d} value={d}>{d} minutes</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex gap-2 justify-end pt-2">
+            <Button variant="outline" size="sm" onClick={() => { reset(); onClose(); }}>Cancel</Button>
+            <Button size="sm" disabled={saving} className="bg-green-700 hover:bg-green-800 text-white" onClick={handleSubmit}>
+              {saving && <Loader2 className="w-3.5 h-3.5 animate-spin mr-1.5" />}
+              Create Window
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Generate Slots Dialog ──────────────────────────────────────────────────────
+
+function GenerateSlotsDialog({
+  open,
+  onClose,
+  windows,
+  teachers,
+  onCreated,
+}: {
+  open: boolean;
+  onClose: () => void;
+  windows: InterviewWindow[];
+  teachers: Teacher[];
+  onCreated: () => void;
+}) {
+  const [windowId, setWindowId] = useState("");
+  const [teacherId, setTeacherId] = useState("");
+  const [slotDate, setSlotDate] = useState("");
+  const [startTime, setStartTime] = useState("09:00");
+  const [endTime, setEndTime] = useState("12:00");
+  const [saving, setSaving] = useState(false);
+  const { toast } = useToast();
+
+  const selectedWindow = windows.find((w) => w.id === windowId);
+  const duration = selectedWindow?.slot_duration_minutes ?? 15;
+
+  const reset = () => {
+    setWindowId(""); setTeacherId(""); setSlotDate(""); setStartTime("09:00"); setEndTime("12:00");
+  };
+
+  const handleGenerate = async () => {
+    if (!windowId || !teacherId || !slotDate || !startTime || !endTime) {
+      toast({ title: "Fill in all fields", variant: "destructive" });
+      return;
+    }
+
+    // Generate slots between startTime and endTime
+    const base = new Date(`${slotDate}T${startTime}`);
+    const end = new Date(`${slotDate}T${endTime}`);
+    const slotsToInsert: { window_id: string; teacher_id: string; slot_date: string; slot_time: string; duration_minutes: number }[] = [];
+    let cur = base;
+    while (cur < end) {
+      slotsToInsert.push({
+        window_id: windowId,
+        teacher_id: teacherId,
+        slot_date: slotDate,
+        slot_time: format(cur, "HH:mm:ss"),
+        duration_minutes: duration,
+      });
+      cur = addMinutes(cur, duration);
+    }
+
+    if (slotsToInsert.length === 0) {
+      toast({ title: "No slots to generate — check your times", variant: "destructive" });
+      return;
+    }
+
+    setSaving(true);
+    const { error } = await (supabase as any).from("interview_slots").insert(slotsToInsert);
+    setSaving(false);
+    if (error) {
+      toast({ title: "Failed to generate slots", description: error.message, variant: "destructive" });
+    } else {
+      toast({ title: `${slotsToInsert.length} slots generated` });
+      reset();
+      onCreated();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) { reset(); onClose(); } }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Generate Interview Slots</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 pt-2">
+          <div>
+            <Label>Interview Window *</Label>
+            <Select value={windowId} onValueChange={setWindowId}>
+              <SelectTrigger className="mt-1">
+                <SelectValue placeholder="Select a window" />
+              </SelectTrigger>
+              <SelectContent>
+                {windows.map((w) => (
+                  <SelectItem key={w.id} value={w.id}>{w.title}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label>Teacher *</Label>
+            <Select value={teacherId} onValueChange={setTeacherId}>
+              <SelectTrigger className="mt-1">
+                <SelectValue placeholder="Select a teacher" />
+              </SelectTrigger>
+              <SelectContent>
+                {teachers.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label>Date *</Label>
+            <Input
+              className="mt-1"
+              type="date"
+              value={slotDate}
+              min={selectedWindow?.start_date}
+              max={selectedWindow?.end_date}
+              onChange={(e) => setSlotDate(e.target.value)}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <Label>Start Time *</Label>
+              <Input className="mt-1" type="time" value={startTime} onChange={(e) => setStartTime(e.target.value)} />
+            </div>
+            <div>
+              <Label>End Time *</Label>
+              <Input className="mt-1" type="time" value={endTime} onChange={(e) => setEndTime(e.target.value)} />
+            </div>
+          </div>
+          {windowId && slotDate && startTime && endTime && (
+            <p className="text-xs text-green-700 bg-green-50 border border-green-200 rounded-lg px-3 py-2">
+              Will generate {Math.floor((new Date(`${slotDate}T${endTime}`).getTime() - new Date(`${slotDate}T${startTime}`).getTime()) / (duration * 60000))} × {duration}-min slots
+            </p>
+          )}
+          <div className="flex gap-2 justify-end pt-2">
+            <Button variant="outline" size="sm" onClick={() => { reset(); onClose(); }}>Cancel</Button>
+            <Button size="sm" disabled={saving} className="bg-green-700 hover:bg-green-800 text-white" onClick={handleGenerate}>
+              {saving && <Loader2 className="w-3.5 h-3.5 animate-spin mr-1.5" />}
+              Generate
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/admin/Reports.tsx
+++ b/src/pages/admin/Reports.tsx
@@ -6,7 +6,7 @@
 
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Download, Play, BarChart2, Users, Calendar, BookOpen, Loader2 } from "lucide-react";
+import { Download, Play, BarChart2, Users, Calendar, BookOpen, Loader2, Filter, X } from "lucide-react";
 import { AdminPageShell } from "@/components/admin/AdminPageShell.tsx";
 import { Button } from "@/components/ui/button.tsx";
 import { useToast } from "@/components/ui/use-toast.ts";
@@ -45,24 +45,31 @@ export function exportCSV(
 type ReportId =
   | "attendance-by-student"
   | "attendance-by-section"
+  | "attendance-log"
   | "full-student-roster"
   | "students-by-section"
   | "hifz-progress";
 
+// ─── Attendance filter types ─────────────────────────────────────────────────
+
+interface AttendanceFilters {
+  dateFrom: string;
+  dateTo: string;
+  section: string;
+}
+
 // ─── Data fetchers ────────────────────────────────────────────────────────────
 
-async function fetchAttendanceByStudent() {
-  // Fetch all active students
-  const { data: students, error: sErr } = await supabase
-    .from("students")
-    .select("id, name, section")
-    .eq("status", "active");
+async function fetchAttendanceByStudent(filters: AttendanceFilters) {
+  let studentQ = supabase.from("students").select("id, name, section").eq("status", "active");
+  if (filters.section) studentQ = studentQ.eq("section", filters.section);
+  const { data: students, error: sErr } = await studentQ;
   if (sErr) throw sErr;
 
-  // Fetch all attendance records
-  const { data: records, error: aErr } = await supabase
-    .from("attendance")
-    .select("student_id, status");
+  let attQ = supabase.from("attendance").select("student_id, status");
+  if (filters.dateFrom) attQ = attQ.gte("date", filters.dateFrom);
+  if (filters.dateTo) attQ = attQ.lte("date", filters.dateTo);
+  const { data: records, error: aErr } = await attQ;
   if (aErr) throw aErr;
 
   const STATUS_KEYS = ["present", "absent", "late", "excused", "sick"] as const;
@@ -93,16 +100,16 @@ async function fetchAttendanceByStudent() {
   return rows;
 }
 
-async function fetchAttendanceBySection() {
-  const { data: students, error: sErr } = await supabase
-    .from("students")
-    .select("id, section")
-    .eq("status", "active");
+async function fetchAttendanceBySection(filters: AttendanceFilters) {
+  let studentQ = supabase.from("students").select("id, section").eq("status", "active");
+  if (filters.section) studentQ = studentQ.eq("section", filters.section);
+  const { data: students, error: sErr } = await studentQ;
   if (sErr) throw sErr;
 
-  const { data: records, error: aErr } = await supabase
-    .from("attendance")
-    .select("student_id, status");
+  let attQ = supabase.from("attendance").select("student_id, status");
+  if (filters.dateFrom) attQ = attQ.gte("date", filters.dateFrom);
+  if (filters.dateTo) attQ = attQ.lte("date", filters.dateTo);
+  const { data: records, error: aErr } = await attQ;
   if (aErr) throw aErr;
 
   const sectionMap: Record<
@@ -142,6 +149,37 @@ async function fetchAttendanceBySection() {
     "Attendance Rate %":
       d.total > 0 ? ((d.present / d.total) * 100).toFixed(1) : "0.0",
   }));
+}
+
+async function fetchAttendanceLog(filters: AttendanceFilters) {
+  let q = (supabase as any)
+    .from("attendance")
+    .select("date, status, notes, students(name, section)")
+    .order("date", { ascending: false })
+    .order("students(name)");
+
+  if (filters.dateFrom) q = q.gte("date", filters.dateFrom);
+  if (filters.dateTo) q = q.lte("date", filters.dateTo);
+
+  const { data, error } = await q;
+  if (error) throw error;
+
+  return (data ?? [])
+    .filter((r: any) => {
+      if (!filters.section) return true;
+      const student = Array.isArray(r.students) ? r.students[0] : r.students;
+      return student?.section === filters.section;
+    })
+    .map((r: any) => {
+      const student = Array.isArray(r.students) ? r.students[0] : r.students;
+      return {
+        Date: r.date,
+        "Student Name": student?.name ?? "",
+        Section: student?.section ?? "",
+        Status: r.status,
+        Notes: r.notes ?? "",
+      };
+    });
 }
 
 async function fetchFullStudentRoster() {
@@ -192,7 +230,6 @@ async function fetchHifzProgress() {
     .order("created_at", { ascending: false });
   if (error) throw error;
 
-  // Keep only the most recent entry per student
   const seen = new Set<string>();
   const latest: typeof data = [];
   for (const row of data ?? []) {
@@ -202,7 +239,6 @@ async function fetchHifzProgress() {
     }
   }
 
-  // Count total entries per student
   const entryCounts: Record<string, number> = {};
   for (const row of data ?? []) {
     entryCounts[row.student_id] = (entryCounts[row.student_id] ?? 0) + 1;
@@ -221,6 +257,22 @@ async function fetchHifzProgress() {
   });
 }
 
+// ─── Default filter values ────────────────────────────────────────────────────
+
+function defaultFilters(): AttendanceFilters {
+  const today = new Date();
+  const firstOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+  return {
+    dateFrom: firstOfMonth.toISOString().split("T")[0],
+    dateTo: today.toISOString().split("T")[0],
+    section: "",
+  };
+}
+
+// ─── Known sections ───────────────────────────────────────────────────────────
+
+const KNOWN_SECTIONS = ["men", "women", "Henri-Bourassa", "Saint-Laurent"];
+
 // ─── Report config ────────────────────────────────────────────────────────────
 
 interface ReportDef {
@@ -229,7 +281,8 @@ interface ReportDef {
   description: string;
   filename: string;
   headers: string[];
-  fetcher: () => Promise<Record<string, unknown>[]>;
+  usesFilters?: boolean;
+  fetcher: (filters: AttendanceFilters) => Promise<Record<string, unknown>[]>;
 }
 
 const SECTIONS: {
@@ -258,6 +311,7 @@ const SECTIONS: {
           "Total Days",
           "Attendance Rate %",
         ],
+        usesFilters: true,
         fetcher: fetchAttendanceByStudent,
       },
       {
@@ -274,7 +328,17 @@ const SECTIONS: {
           "Excused",
           "Attendance Rate %",
         ],
+        usesFilters: true,
         fetcher: fetchAttendanceBySection,
+      },
+      {
+        id: "attendance-log",
+        name: "Full Attendance Log",
+        description: "Raw date-stamped records for every student — ideal for government reporting.",
+        filename: "attendance-log",
+        headers: ["Date", "Student Name", "Section", "Status", "Notes"],
+        usesFilters: true,
+        fetcher: fetchAttendanceLog,
       },
     ],
   },
@@ -301,7 +365,7 @@ const SECTIONS: {
           "Enrollment Date",
           "Status",
         ],
-        fetcher: fetchFullStudentRoster,
+        fetcher: (_f) => fetchFullStudentRoster(),
       },
       {
         id: "students-by-section",
@@ -309,7 +373,7 @@ const SECTIONS: {
         description: "Count of active students per section.",
         filename: "students-by-section",
         headers: ["Section", "Student Count"],
-        fetcher: fetchStudentsBySection,
+        fetcher: (_f) => fetchStudentsBySection(),
       },
     ],
   },
@@ -331,7 +395,7 @@ const SECTIONS: {
           "Date (last entry)",
           "Total Entries",
         ],
-        fetcher: fetchHifzProgress,
+        fetcher: (_f) => fetchHifzProgress(),
       },
     ],
   },
@@ -371,6 +435,9 @@ function ReportRow({ report, isActive, onGenerate, data, isLoading }: ReportRowP
       <div className="min-w-0">
         <p className="text-sm font-medium text-gray-700">{report.name}</p>
         <p className="text-xs text-gray-400 mt-0.5 truncate">{report.description}</p>
+        {report.usesFilters && (
+          <p className="text-xs text-green-600 mt-0.5">Uses date &amp; section filters ↑</p>
+        )}
         {isActive && data && (
           <p className="text-xs text-green-700 font-medium mt-1">
             {data.length} row{data.length !== 1 ? "s" : ""} ready
@@ -410,36 +477,54 @@ function ReportRow({ report, isActive, onGenerate, data, isLoading }: ReportRowP
 
 export default function Reports() {
   const [activeReport, setActiveReport] = useState<ReportId | null>(null);
+  const [filters, setFilters] = useState<AttendanceFilters>(defaultFilters);
+
+  const updateFilter = (key: keyof AttendanceFilters, value: string) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+    // Clear active report so stale data doesn't linger
+    setActiveReport(null);
+  };
+
+  const resetFilters = () => {
+    setFilters(defaultFilters());
+    setActiveReport(null);
+  };
 
   // One query per report — all start disabled, enabled only when activeReport matches
   const queries: Record<ReportId, ReturnType<typeof useQuery>> = {
     "attendance-by-student": useQuery({
-      queryKey: ["report", "attendance-by-student"],
-      queryFn: fetchAttendanceByStudent,
+      queryKey: ["report", "attendance-by-student", filters],
+      queryFn: () => fetchAttendanceByStudent(filters),
       enabled: activeReport === "attendance-by-student",
-      staleTime: 5 * 60 * 1000,
+      staleTime: 0,
     }),
     "attendance-by-section": useQuery({
-      queryKey: ["report", "attendance-by-section"],
-      queryFn: fetchAttendanceBySection,
+      queryKey: ["report", "attendance-by-section", filters],
+      queryFn: () => fetchAttendanceBySection(filters),
       enabled: activeReport === "attendance-by-section",
-      staleTime: 5 * 60 * 1000,
+      staleTime: 0,
+    }),
+    "attendance-log": useQuery({
+      queryKey: ["report", "attendance-log", filters],
+      queryFn: () => fetchAttendanceLog(filters),
+      enabled: activeReport === "attendance-log",
+      staleTime: 0,
     }),
     "full-student-roster": useQuery({
       queryKey: ["report", "full-student-roster"],
-      queryFn: fetchFullStudentRoster,
+      queryFn: () => fetchFullStudentRoster(),
       enabled: activeReport === "full-student-roster",
       staleTime: 5 * 60 * 1000,
     }),
     "students-by-section": useQuery({
       queryKey: ["report", "students-by-section"],
-      queryFn: fetchStudentsBySection,
+      queryFn: () => fetchStudentsBySection(),
       enabled: activeReport === "students-by-section",
       staleTime: 5 * 60 * 1000,
     }),
     "hifz-progress": useQuery({
       queryKey: ["report", "hifz-progress"],
-      queryFn: fetchHifzProgress,
+      queryFn: () => fetchHifzProgress(),
       enabled: activeReport === "hifz-progress",
       staleTime: 5 * 60 * 1000,
     }),
@@ -453,6 +538,54 @@ export default function Reports() {
       iconBg="bg-green-50"
     >
       <div className="space-y-6">
+        {/* ── Attendance filter bar ──────────────────────────────────────── */}
+        <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5">
+          <div className="flex items-center gap-2 border-l-2 border-green-600 pl-3 mb-4">
+            <Filter className="w-4 h-4 text-green-600" />
+            <h2 className="text-base font-bold text-gray-900 tracking-tight">Attendance Filters</h2>
+            <span className="text-xs text-gray-400 ml-1">— applies to all Attendance Reports</span>
+          </div>
+          <div className="flex flex-wrap gap-3 items-end">
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">From</label>
+              <input
+                type="date"
+                value={filters.dateFrom}
+                onChange={(e) => updateFilter("dateFrom", e.target.value)}
+                className="text-sm border border-gray-200 rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-green-500"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">To</label>
+              <input
+                type="date"
+                value={filters.dateTo}
+                onChange={(e) => updateFilter("dateTo", e.target.value)}
+                className="text-sm border border-gray-200 rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-green-500"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">Section</label>
+              <select
+                value={filters.section}
+                onChange={(e) => updateFilter("section", e.target.value)}
+                className="text-sm border border-gray-200 rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-green-500 bg-white"
+              >
+                <option value="">All sections</option>
+                {KNOWN_SECTIONS.map((s) => (
+                  <option key={s} value={s}>{s}</option>
+                ))}
+              </select>
+            </div>
+            <button
+              onClick={resetFilters}
+              className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-700 transition-colors pb-1.5"
+            >
+              <X className="w-3 h-3" /> Reset
+            </button>
+          </div>
+        </div>
+
         {SECTIONS.map((section) => (
           <div
             key={section.title}

--- a/supabase/functions/attendance-absence-email/index.ts
+++ b/supabase/functions/attendance-absence-email/index.ts
@@ -175,35 +175,88 @@ function htmlEscape(str: string): string {
   }[c] as string));
 }
 
-const STATUS_STYLES_MAP: Record<string, { color: string; bg: string; border: string; label: string }> = {
-  present:         { color: "#059669", bg: "#f0fdf4", border: "#34d399", label: "Present" },
-  absent:          { color: "#dc2626", bg: "#fef2f2", border: "#f87171", label: "Absent" },
-  late:            { color: "#d97706", bg: "#fffbeb", border: "#fbbf24", label: "Late" },
-  excused:         { color: "#7c3aed", bg: "#faf5ff", border: "#a78bfa", label: "Excused" },
-  early_departure: { color: "#ea580c", bg: "#fff7ed", border: "#fb923c", label: "Early Departure" },
-  sick:            { color: "#0891b2", bg: "#f0f9ff", border: "#38bdf8", label: "Sick" },
+const STATUS_STYLES_MAP: Record<
+  string,
+  { color: string; bg: string; border: string; label: string }
+> = {
+  present: {
+    color: "#059669",
+    bg: "#f0fdf4",
+    border: "#34d399",
+    label: "Present",
+  },
+  absent: {
+    color: "#dc2626",
+    bg: "#fef2f2",
+    border: "#f87171",
+    label: "Absent",
+  },
+  late: { color: "#d97706", bg: "#fffbeb", border: "#fbbf24", label: "Late" },
+  excused: {
+    color: "#7c3aed",
+    bg: "#faf5ff",
+    border: "#a78bfa",
+    label: "Excused",
+  },
+  early_departure: {
+    color: "#ea580c",
+    bg: "#fff7ed",
+    border: "#fb923c",
+    label: "Early Departure",
+  },
+  sick: { color: "#0891b2", bg: "#f0f9ff", border: "#38bdf8", label: "Sick" },
 };
-const DEFAULT_STATUS_STYLE = { color: "#6b7280", bg: "#f9fafb", border: "#d1d5db", label: "Not Marked" };
+const DEFAULT_STATUS_STYLE = {
+  color: "#6b7280",
+  bg: "#f9fafb",
+  border: "#d1d5db",
+  label: "Not Marked",
+};
 
 function buildAttendanceEmailHtml(p: {
-  studentName: string; guardianName: string; status: string;
-  dateYmd: string; time?: string | null; logoUrl: string; appUrl: string;
+  studentName: string;
+  guardianName: string;
+  status: string;
+  dateYmd: string;
+  time?: string | null;
+  logoUrl: string;
+  appUrl: string;
 }): string {
   const st = STATUS_STYLES_MAP[p.status] ?? DEFAULT_STATUS_STYLE;
-  const safeStudent  = htmlEscape(p.studentName || "Student");
+  const safeStudent = htmlEscape(p.studentName || "Student");
   const safeGuardian = htmlEscape(p.guardianName || "");
-  const safeDate     = htmlEscape(p.dateYmd);
-  const dispTime     = p.time ? formatDisplayTime(p.time) : null;
-  const timeStr      = dispTime ? ` at ${htmlEscape(dispTime)}` : "";
+  const safeDate = htmlEscape(p.dateYmd);
+  const dispTime = p.time ? formatDisplayTime(p.time) : null;
+  const timeStr = dispTime ? ` at ${htmlEscape(dispTime)}` : "";
   let narrative: string;
   switch (p.status) {
-    case "present":         narrative = `<strong>${safeStudent}</strong> attended class and was marked <strong>Present</strong> on ${safeDate}.`; break;
-    case "absent":          narrative = `<strong>${safeStudent}</strong> was marked <strong>Absent</strong> on ${safeDate}. If this is unexpected, please contact the school office. We hope everything is well.`; break;
-    case "late":            narrative = `<strong>${safeStudent}</strong> arrived <strong>late${timeStr}</strong> on ${safeDate}. Please encourage timely arrival to avoid missing lessons.`; break;
-    case "early_departure": narrative = `<strong>${safeStudent}</strong> was marked for <strong>Early Departure${timeStr}</strong> on ${safeDate}.`; break;
-    case "excused":         narrative = `<strong>${safeStudent}</strong> was marked <strong>Excused</strong> on ${safeDate}. The absence has been recorded by the school.`; break;
-    case "sick":            narrative = `<strong>${safeStudent}</strong> was marked <strong>Sick</strong> on ${safeDate}. We wish them a speedy recovery and look forward to their return.`; break;
-    default:                narrative = `<strong>${safeStudent}</strong> has not been marked yet for ${safeDate}. Please contact the school if you have any concerns.`;
+    case "present":
+      narrative =
+        `<strong>${safeStudent}</strong> attended class and was marked <strong>Present</strong> on ${safeDate}.`;
+      break;
+    case "absent":
+      narrative =
+        `<strong>${safeStudent}</strong> was marked <strong>Absent</strong> on ${safeDate}. If this is unexpected, please contact the school office. We hope everything is well.`;
+      break;
+    case "late":
+      narrative =
+        `<strong>${safeStudent}</strong> arrived <strong>late${timeStr}</strong> on ${safeDate}. Please encourage timely arrival to avoid missing lessons.`;
+      break;
+    case "early_departure":
+      narrative =
+        `<strong>${safeStudent}</strong> was marked for <strong>Early Departure${timeStr}</strong> on ${safeDate}.`;
+      break;
+    case "excused":
+      narrative =
+        `<strong>${safeStudent}</strong> was marked <strong>Excused</strong> on ${safeDate}. The absence has been recorded by the school.`;
+      break;
+    case "sick":
+      narrative =
+        `<strong>${safeStudent}</strong> was marked <strong>Sick</strong> on ${safeDate}. We wish them a speedy recovery and look forward to their return.`;
+      break;
+    default:
+      narrative =
+        `<strong>${safeStudent}</strong> has not been marked yet for ${safeDate}. Please contact the school if you have any concerns.`;
   }
   return `<!DOCTYPE html>
 <html lang="en">
@@ -231,14 +284,18 @@ function buildAttendanceEmailHtml(p: {
         </td>
         <td style="vertical-align:middle;border-left:2px solid ${st.border};padding-left:16px;">
           <p style="margin:0;color:#111827;font-size:18px;font-weight:700;">${safeStudent}</p>
-          <p style="margin:4px 0 0;color:#6b7280;font-size:13px;">${safeDate}${timeStr ? " &nbsp;&middot;&nbsp;" + timeStr : ""}</p>
+          <p style="margin:4px 0 0;color:#6b7280;font-size:13px;">${safeDate}${
+    timeStr ? " &nbsp;&middot;&nbsp;" + timeStr : ""
+  }</p>
         </td>
       </tr></table>
     </td>
   </tr>
   <tr>
     <td style="padding:32px 40px 24px;">
-      <p style="margin:0 0 12px;color:#111827;font-size:16px;">Assalamu alaikum${safeGuardian ? ` <strong>${safeGuardian}</strong>` : ""},</p>
+      <p style="margin:0 0 12px;color:#111827;font-size:16px;">Assalamu alaikum${
+    safeGuardian ? ` <strong>${safeGuardian}</strong>` : ""
+  },</p>
       <p style="margin:0 0 28px;color:#4b5563;font-size:15px;line-height:1.65;">${narrative}</p>
       <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:28px;"><tr><td style="border-top:1px solid #e5e7eb;">&nbsp;</td></tr></table>
       <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:24px;">

--- a/supabase/functions/daily-progress-email/index.ts
+++ b/supabase/functions/daily-progress-email/index.ts
@@ -677,7 +677,9 @@ serve(async (req: Request) => {
         const topStudent = studentsMap.get(topEntry[0]);
         if (topStudent) {
           topStudentHtml =
-            `<p style="margin:8px 0 12px;font-size:14px;color:#059669;font-weight:600;">&#127942; Top Sabaq: <strong>${topStudent.name}</strong> &mdash; ${topEntry[1]} pages</p>`;
+            `<p style="margin:8px 0 12px;font-size:14px;color:#059669;font-weight:600;">&#127942; Top Sabaq: <strong>${topStudent.name}</strong> &mdash; ${
+              topEntry[1]
+            } pages</p>`;
         }
       }
 
@@ -718,7 +720,9 @@ serve(async (req: Request) => {
           classAssignmentsHtml += `
             <tr style="background:#ffffff;">
               <td style="padding:10px 14px;border-bottom:1px solid #f3f4f6;font-size:14px;color:#111827;">${title}</td>
-              <td style="padding:10px 14px;border-bottom:1px solid #f3f4f6;font-size:14px;color:#6b7280;">${due || "&mdash;"}</td>
+              <td style="padding:10px 14px;border-bottom:1px solid #f3f4f6;font-size:14px;color:#6b7280;">${
+            due || "&mdash;"
+          }</td>
               <td style="padding:10px 14px;border-bottom:1px solid #f3f4f6;font-size:14px;color:#111827;font-weight:600;">${count}</td>
             </tr>`;
         }
@@ -731,7 +735,11 @@ serve(async (req: Request) => {
           ${topStudentHtml}
           <p style="margin:0 0 8px;color:#374151;font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Sabaq Today</p>
           ${classProgressHtml}
-          ${assignmentAggregate.size > 0 ? `<p style="margin:16px 0 8px;color:#374151;font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Assignments (Last 24h)</p>${classAssignmentsHtml}` : ""}
+          ${
+        assignmentAggregate.size > 0
+          ? `<p style="margin:16px 0 8px;color:#374151;font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Assignments (Last 24h)</p>${classAssignmentsHtml}`
+          : ""
+      }
         </div>`;
     }
 
@@ -750,7 +758,9 @@ serve(async (req: Request) => {
   <!-- Header gradient -->
   <tr>
     <td style="background:linear-gradient(135deg,#052e16 0%,#166534 60%,#16a34a 100%);padding:36px 40px 28px;text-align:center;">
-      ${logoImgHtml ? `<div style="margin-bottom:16px;">${logoImgHtml}</div>` : ""}
+      ${
+      logoImgHtml ? `<div style="margin-bottom:16px;">${logoImgHtml}</div>` : ""
+    }
       <div style="display:inline-block;background:rgba(255,255,255,0.15);border-radius:8px;padding:6px 16px;margin-bottom:12px;">
         <span style="color:#bbf7d0;font-size:12px;font-weight:700;letter-spacing:1px;text-transform:uppercase;">Principal Report</span>
       </div>
@@ -773,7 +783,10 @@ serve(async (req: Request) => {
   <!-- Class sections -->
   <tr>
     <td style="padding:24px 40px;">
-      ${classSectionsHtml || `<p style="color:#6b7280;font-size:14px;text-align:center;padding:32px 0;">No activity detected for today.</p>`}
+      ${
+      classSectionsHtml ||
+      `<p style="color:#6b7280;font-size:14px;text-align:center;padding:32px 0;">No activity detected for today.</p>`
+    }
     </td>
   </tr>
 
@@ -787,7 +800,13 @@ serve(async (req: Request) => {
         <tr>
           <td style="background:#f0fdf4;border-radius:8px;padding:12px 16px;">
             <p style="margin:0;color:#166534;font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Report Info</p>
-            <p style="margin:4px 0 0;color:#374151;font-size:13px;">Generated <strong>${triggerSource === "scheduled" ? "automatically (scheduled)" : "manually"}</strong> at ${new Date(timestamp).toLocaleString("en-CA", { timeZone: REPORT_TIME_ZONE })}</p>
+            <p style="margin:4px 0 0;color:#374151;font-size:13px;">Generated <strong>${
+      triggerSource === "scheduled" ? "automatically (scheduled)" : "manually"
+    }</strong> at ${
+      new Date(timestamp).toLocaleString("en-CA", {
+        timeZone: REPORT_TIME_ZONE,
+      })
+    }</p>
           </td>
         </tr>
       </table>
@@ -910,7 +929,9 @@ serve(async (req: Request) => {
           <td style="padding:10px 14px;border-bottom:1px solid #f3f4f6;font-size:14px;color:#111827;">Surah ${p.current_surah}:${p.start_ayat}&ndash;${p.end_ayat}</td>
           <td style="padding:10px 14px;border-bottom:1px solid #f3f4f6;font-size:14px;color:#111827;font-weight:600;">${p.pages_memorized}</td>
           <td style="padding:10px 14px;border-bottom:1px solid #f3f4f6;font-size:14px;color:#059669;font-weight:600;">${p.memorization_quality}</td>
-          <td style="padding:10px 14px;border-bottom:1px solid #f3f4f6;font-size:14px;color:#6b7280;">${p.teacher_notes || p.notes || "&mdash;"}</td>
+          <td style="padding:10px 14px;border-bottom:1px solid #f3f4f6;font-size:14px;color:#6b7280;">${
+          p.teacher_notes || p.notes || "&mdash;"
+        }</td>
         </tr>`
       ).join("");
 
@@ -1017,7 +1038,11 @@ serve(async (req: Request) => {
             const dueText = r.due_date ? r.due_date : "&mdash;";
             const gradeText = r.grade || "&mdash;";
             const feedbackText = r.feedback || "&mdash;";
-            const statusColor = r.status === "graded" ? "#059669" : r.status === "submitted" ? "#2563eb" : "#6b7280";
+            const statusColor = r.status === "graded"
+              ? "#059669"
+              : r.status === "submitted"
+              ? "#2563eb"
+              : "#6b7280";
             return `
               <tr style="background:${idx % 2 === 0 ? "#ffffff" : "#f9fafb"};">
                 <td style="padding:10px 14px;border-bottom:1px solid #f3f4f6;font-size:14px;color:#111827;word-break:break-word;">${r.title}</td>
@@ -1035,7 +1060,9 @@ serve(async (req: Request) => {
 
       const academicSection = `
         <p style="margin:28px 0 10px;color:#052e16;font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:0.8px;border-bottom:2px solid #d1fae5;padding-bottom:8px;">Academic Updates</p>
-        <p style="margin:0 0 12px;color:#4b5563;font-size:14px;">Recent assignment activity for ${student.name}${academicRows ? "" : " &mdash; no recent updates"}.</p>
+        <p style="margin:0 0 12px;color:#4b5563;font-size:14px;">Recent assignment activity for ${student.name}${
+        academicRows ? "" : " &mdash; no recent updates"
+      }.</p>
         <table border="0" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;border:1px solid #e5e7eb;border-radius:8px;overflow:hidden;">
           <thead>
             <tr style="background:#f0fdf4;">
@@ -1047,7 +1074,10 @@ serve(async (req: Request) => {
             </tr>
           </thead>
           <tbody>
-            ${academicRows || '<tr><td colspan="5" style="padding:12px 14px;color:#9ca3af;font-size:14px;">No recent academic activity.</td></tr>'}
+            ${
+        academicRows ||
+        '<tr><td colspan="5" style="padding:12px 14px;color:#9ca3af;font-size:14px;">No recent academic activity.</td></tr>'
+      }
           </tbody>
         </table>
       `;
@@ -1075,7 +1105,9 @@ serve(async (req: Request) => {
   </tr>
   <tr>
     <td style="padding:32px 40px 24px;">
-      <p style="margin:0 0 16px;color:#111827;font-size:16px;">Assalamu alaikum <strong>${student.guardian_name || "Guardian"}</strong>,</p>
+      <p style="margin:0 0 16px;color:#111827;font-size:16px;">Assalamu alaikum <strong>${
+        student.guardian_name || "Guardian"
+      }</strong>,</p>
       <p style="margin:0 0 24px;color:#4b5563;font-size:15px;line-height:1.6;">Here is today&rsquo;s Quran memorization progress report for <strong>${student.name}</strong>.</p>
       <p style="margin:0 0 10px;color:#052e16;font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:0.8px;border-bottom:2px solid #d1fae5;padding-bottom:8px;">Sabaq Today</p>
       <table border="0" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;border:1px solid #e5e7eb;border-radius:8px;overflow:hidden;margin-bottom:28px;">
@@ -1104,7 +1136,9 @@ serve(async (req: Request) => {
       </table>
       <p style="margin:0;color:#9ca3af;font-size:12px;text-align:center;line-height:1.5;">
         JazakAllah Khairan for your continued support.<br>
-        Generated ${triggerSource === "scheduled" ? "automatically" : "manually"} on ${fmtDate(timestamp)}.
+        Generated ${
+        triggerSource === "scheduled" ? "automatically" : "manually"
+      } on ${fmtDate(timestamp)}.
       </p>
     </td>
   </tr>

--- a/supabase/functions/delete-teacher/index.ts
+++ b/supabase/functions/delete-teacher/index.ts
@@ -55,15 +55,23 @@ serve(async (req: Request) => {
         .contains("teacher_ids", [userId]);
       if (classes && classes.length > 0) {
         for (const cls of classes) {
-          const newIds = (cls.teacher_ids || []).filter((id: string) => id !== userId);
-          await admin.from("classes").update({ teacher_ids: newIds }).eq("id", cls.id);
+          const newIds = (cls.teacher_ids || []).filter((id: string) =>
+            id !== userId
+          );
+          await admin.from("classes").update({ teacher_ids: newIds }).eq(
+            "id",
+            cls.id,
+          );
         }
       }
     } catch (_e) { /* ignore */ }
 
     // ── 2. Remove teacher from classes.current_teacher_id ──────────
     try {
-      await admin.from("classes").update({ current_teacher_id: null }).eq("current_teacher_id", userId);
+      await admin.from("classes").update({ current_teacher_id: null }).eq(
+        "current_teacher_id",
+        userId,
+      );
     } catch (_e) { /* ignore */ }
 
     // ── 3. Clean up students_teachers ──────────────────────────────
@@ -78,7 +86,9 @@ serve(async (req: Request) => {
 
     // ── 5. Delete messages sent/received ───────────────────────────
     try {
-      await admin.from("communications").delete().or(`sender_id.eq.${userId},recipient_id.eq.${userId}`);
+      await admin.from("communications").delete().or(
+        `sender_id.eq.${userId},recipient_id.eq.${userId}`,
+      );
     } catch (_e) { /* ignore */ }
 
     // ── 6. Delete teacher tasks ─────────────────────────────────────
@@ -109,8 +119,13 @@ serve(async (req: Request) => {
     if (profileDelErr) {
       console.error("Profile delete error:", profileDelErr);
       return new Response(
-        JSON.stringify({ error: `Failed to delete profile: ${profileDelErr.message}` }),
-        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+        JSON.stringify({
+          error: `Failed to delete profile: ${profileDelErr.message}`,
+        }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
       );
     }
 

--- a/supabase/functions/send-interview-confirmation/index.ts
+++ b/supabase/functions/send-interview-confirmation/index.ts
@@ -1,0 +1,187 @@
+// @ts-nocheck
+// =================================================================================
+// Edge Function: send-interview-confirmation
+// Called after a parent books an interview slot.
+// Sends a confirmation email to the parent with date/time/teacher details.
+//
+// Request body:
+//   { slot_id: string, student_id: string, parent_id: string }
+// =================================================================================
+
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { Resend } from "https://esm.sh/resend@2.0.0";
+
+const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
+const FROM_EMAIL = Deno.env.get("RESEND_FROM_EMAIL") || "noreply@daralulummontreal.com";
+const APP_URL = Deno.env.get("APP_URL") || "https://app.daralulummontreal.com";
+const LOGO_URL = Deno.env.get("LOGO_URL") ||
+  "https://depsfpodwaprzxffdcks.supabase.co/storage/v1/object/public/dum-logo/dum-logo.png";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+    );
+
+    const { slot_id, student_id, parent_id } = await req.json();
+
+    if (!slot_id || !student_id || !parent_id) {
+      return new Response(
+        JSON.stringify({ error: "slot_id, student_id, parent_id required" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
+
+    // Fetch slot with teacher + window
+    const { data: slot, error: slotErr } = await supabase
+      .from("interview_slots")
+      .select("slot_date, slot_time, duration_minutes, teacher:profiles!interview_slots_teacher_id_fkey(name), window:interview_windows!interview_slots_window_id_fkey(title)")
+      .eq("id", slot_id)
+      .single();
+
+    if (slotErr || !slot) {
+      return new Response(
+        JSON.stringify({ error: "Slot not found" }),
+        { status: 404, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
+
+    // Fetch student name
+    const { data: student } = await supabase
+      .from("students")
+      .select("name")
+      .eq("id", student_id)
+      .maybeSingle();
+
+    // Fetch parent profile
+    const { data: parent } = await supabase
+      .from("profiles")
+      .select("name, email")
+      .eq("id", parent_id)
+      .maybeSingle();
+
+    if (!parent?.email) {
+      return new Response(
+        JSON.stringify({ message: "Parent has no email — skipped", sent: 0 }),
+        { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
+
+    // Format date/time
+    const slotDate = new Date(slot.slot_date + "T" + slot.slot_time);
+    const dateStr = slotDate.toLocaleDateString("en-CA", { weekday: "long", year: "numeric", month: "long", day: "numeric" });
+    const timeStr = slotDate.toLocaleTimeString("en-CA", { hour: "numeric", minute: "2-digit", hour12: true });
+    const teacherName = (slot.teacher as any)?.name ?? "your child's teacher";
+    const windowTitle = (slot.window as any)?.title ?? "Parent-Teacher Interview";
+    const studentName = student?.name ?? "Your child";
+    const parentName = parent.name ?? "Parent";
+
+    const html = `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8" /></head>
+<body style="margin:0;padding:0;background:#f5f6fa;font-family:sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f5f6fa;padding:32px 0;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:16px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.08);">
+        <!-- Header -->
+        <tr>
+          <td style="background:linear-gradient(135deg,#052e16 0%,#14532d 55%,#166534 100%);padding:28px 32px;">
+            <img src="${LOGO_URL}" alt="DUM Logo" height="36" style="display:block;margin-bottom:14px;" />
+            <p style="margin:0;font-size:20px;font-weight:700;color:#fff;">Interview Confirmed</p>
+            <p style="margin:4px 0 0;font-size:13px;color:#86efac;">Dār Al-Ulūm Montréal</p>
+          </td>
+        </tr>
+        <!-- Body -->
+        <tr>
+          <td style="padding:28px 32px;">
+            <p style="margin:0 0 16px;font-size:15px;color:#374151;">Dear ${parentName},</p>
+            <p style="margin:0 0 20px;font-size:15px;color:#374151;">
+              Your parent-teacher interview for <strong>${studentName}</strong> has been confirmed.
+            </p>
+            <!-- Details card -->
+            <table width="100%" cellpadding="0" cellspacing="0" style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:10px;overflow:hidden;margin-bottom:20px;">
+              <tr>
+                <td style="padding:20px 24px;">
+                  <p style="margin:0 0 4px;font-size:12px;color:#166534;font-weight:600;text-transform:uppercase;letter-spacing:.06em;">${windowTitle}</p>
+                  <table width="100%" cellpadding="0" cellspacing="0" style="margin-top:12px;">
+                    <tr>
+                      <td style="padding:4px 0;font-size:13px;color:#6b7280;width:100px;">Date</td>
+                      <td style="padding:4px 0;font-size:14px;font-weight:600;color:#1f2937;">${dateStr}</td>
+                    </tr>
+                    <tr>
+                      <td style="padding:4px 0;font-size:13px;color:#6b7280;">Time</td>
+                      <td style="padding:4px 0;font-size:14px;font-weight:600;color:#1f2937;">${timeStr} (${slot.duration_minutes} min)</td>
+                    </tr>
+                    <tr>
+                      <td style="padding:4px 0;font-size:13px;color:#6b7280;">Teacher</td>
+                      <td style="padding:4px 0;font-size:14px;font-weight:600;color:#1f2937;">${teacherName}</td>
+                    </tr>
+                    <tr>
+                      <td style="padding:4px 0;font-size:13px;color:#6b7280;">Student</td>
+                      <td style="padding:4px 0;font-size:14px;font-weight:600;color:#1f2937;">${studentName}</td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+            <p style="margin:0 0 20px;font-size:13px;color:#6b7280;">
+              If you need to reschedule or cancel, please log in to the parent portal.
+            </p>
+            <a href="${APP_URL}/parent/interviews"
+               style="display:inline-block;background:#15803d;color:#fff;font-weight:600;font-size:13px;padding:10px 22px;border-radius:8px;text-decoration:none;">
+              View in Parent Portal
+            </a>
+          </td>
+        </tr>
+        <!-- Footer -->
+        <tr>
+          <td style="padding:16px 32px;border-top:1px solid #f3f4f6;">
+            <p style="margin:0;font-size:12px;color:#9ca3af;">Dār Al-Ulūm Montréal · Automated notification</p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+
+    const resend = new Resend(RESEND_API_KEY);
+    const { error: emailErr } = await resend.emails.send({
+      from: FROM_EMAIL,
+      to: parent.email,
+      subject: `Interview Confirmed: ${dateStr} at ${timeStr} with ${teacherName}`,
+      html,
+    });
+
+    if (emailErr) {
+      console.error("Resend error:", emailErr);
+      return new Response(
+        JSON.stringify({ success: false, error: emailErr }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, sent: 1 }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  } catch (err) {
+    console.error("Unexpected error:", err);
+    return new Response(
+      JSON.stringify({ error: String(err) }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+});

--- a/supabase/functions/send-interview-confirmation/index.ts
+++ b/supabase/functions/send-interview-confirmation/index.ts
@@ -13,14 +13,16 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { Resend } from "https://esm.sh/resend@2.0.0";
 
 const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
-const FROM_EMAIL = Deno.env.get("RESEND_FROM_EMAIL") || "noreply@daralulummontreal.com";
+const FROM_EMAIL = Deno.env.get("RESEND_FROM_EMAIL") ||
+  "noreply@daralulummontreal.com";
 const APP_URL = Deno.env.get("APP_URL") || "https://app.daralulummontreal.com";
 const LOGO_URL = Deno.env.get("LOGO_URL") ||
   "https://depsfpodwaprzxffdcks.supabase.co/storage/v1/object/public/dum-logo/dum-logo.png";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
 };
 
@@ -40,21 +42,29 @@ serve(async (req) => {
     if (!slot_id || !student_id || !parent_id) {
       return new Response(
         JSON.stringify({ error: "slot_id, student_id, parent_id required" }),
-        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
       );
     }
 
     // Fetch slot with teacher + window
     const { data: slot, error: slotErr } = await supabase
       .from("interview_slots")
-      .select("slot_date, slot_time, duration_minutes, teacher:profiles!interview_slots_teacher_id_fkey(name), window:interview_windows!interview_slots_window_id_fkey(title)")
+      .select(
+        "slot_date, slot_time, duration_minutes, teacher:profiles!interview_slots_teacher_id_fkey(name), window:interview_windows!interview_slots_window_id_fkey(title)",
+      )
       .eq("id", slot_id)
       .single();
 
     if (slotErr || !slot) {
       return new Response(
         JSON.stringify({ error: "Slot not found" }),
-        { status: 404, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+        {
+          status: 404,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
       );
     }
 
@@ -81,10 +91,20 @@ serve(async (req) => {
 
     // Format date/time
     const slotDate = new Date(slot.slot_date + "T" + slot.slot_time);
-    const dateStr = slotDate.toLocaleDateString("en-CA", { weekday: "long", year: "numeric", month: "long", day: "numeric" });
-    const timeStr = slotDate.toLocaleTimeString("en-CA", { hour: "numeric", minute: "2-digit", hour12: true });
+    const dateStr = slotDate.toLocaleDateString("en-CA", {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+    const timeStr = slotDate.toLocaleTimeString("en-CA", {
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    });
     const teacherName = (slot.teacher as any)?.name ?? "your child's teacher";
-    const windowTitle = (slot.window as any)?.title ?? "Parent-Teacher Interview";
+    const windowTitle = (slot.window as any)?.title ??
+      "Parent-Teacher Interview";
     const studentName = student?.name ?? "Your child";
     const parentName = parent.name ?? "Parent";
 
@@ -161,7 +181,8 @@ serve(async (req) => {
     const { error: emailErr } = await resend.emails.send({
       from: FROM_EMAIL,
       to: parent.email,
-      subject: `Interview Confirmed: ${dateStr} at ${timeStr} with ${teacherName}`,
+      subject:
+        `Interview Confirmed: ${dateStr} at ${timeStr} with ${teacherName}`,
       html,
     });
 
@@ -169,7 +190,10 @@ serve(async (req) => {
       console.error("Resend error:", emailErr);
       return new Response(
         JSON.stringify({ success: false, error: emailErr }),
-        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
       );
     }
 
@@ -181,7 +205,10 @@ serve(async (req) => {
     console.error("Unexpected error:", err);
     return new Response(
       JSON.stringify({ error: String(err) }),
-      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
     );
   }
 });

--- a/supabase/migrations/20260511000000_create_interview_tables.sql
+++ b/supabase/migrations/20260511000000_create_interview_tables.sql
@@ -1,0 +1,67 @@
+-- Interview Windows: admin creates a block of time for interviews
+CREATE TABLE IF NOT EXISTS interview_windows (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title text NOT NULL,
+  description text,
+  start_date date NOT NULL,
+  end_date date NOT NULL,
+  slot_duration_minutes int NOT NULL DEFAULT 15,
+  created_by uuid REFERENCES profiles(id) ON DELETE SET NULL,
+  created_at timestamptz DEFAULT now()
+);
+
+-- Interview Slots: individual bookable time slots
+CREATE TABLE IF NOT EXISTS interview_slots (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  window_id uuid NOT NULL REFERENCES interview_windows(id) ON DELETE CASCADE,
+  teacher_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  slot_date date NOT NULL,
+  slot_time time NOT NULL,
+  duration_minutes int NOT NULL DEFAULT 15,
+  created_at timestamptz DEFAULT now()
+);
+
+-- Interview Bookings: parent books a slot
+CREATE TABLE IF NOT EXISTS interview_bookings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  slot_id uuid NOT NULL REFERENCES interview_slots(id) ON DELETE CASCADE UNIQUE,
+  student_id uuid NOT NULL REFERENCES students(id) ON DELETE CASCADE,
+  parent_id uuid REFERENCES profiles(id) ON DELETE SET NULL,
+  notes text,
+  status text NOT NULL DEFAULT 'confirmed'
+    CHECK (status IN ('confirmed', 'cancelled', 'no_show')),
+  created_at timestamptz DEFAULT now()
+);
+
+-- RLS
+ALTER TABLE interview_windows ENABLE ROW LEVEL SECURITY;
+ALTER TABLE interview_slots ENABLE ROW LEVEL SECURITY;
+ALTER TABLE interview_bookings ENABLE ROW LEVEL SECURITY;
+
+-- Windows: everyone reads, only admins write
+CREATE POLICY "interview_windows_select" ON interview_windows FOR SELECT USING (true);
+CREATE POLICY "interview_windows_admin_all" ON interview_windows FOR ALL USING (
+  EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND role = 'admin')
+);
+
+-- Slots: everyone reads, only admins write
+CREATE POLICY "interview_slots_select" ON interview_slots FOR SELECT USING (true);
+CREATE POLICY "interview_slots_admin_all" ON interview_slots FOR ALL USING (
+  EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND role = 'admin')
+);
+
+-- Bookings: admins + teachers see all; parents see own
+CREATE POLICY "interview_bookings_select" ON interview_bookings FOR SELECT USING (
+  EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND role IN ('admin', 'teacher'))
+  OR parent_id = auth.uid()
+);
+CREATE POLICY "interview_bookings_insert_parent" ON interview_bookings FOR INSERT WITH CHECK (
+  parent_id = auth.uid()
+);
+CREATE POLICY "interview_bookings_update" ON interview_bookings FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND role = 'admin')
+  OR parent_id = auth.uid()
+);
+CREATE POLICY "interview_bookings_delete_admin" ON interview_bookings FOR DELETE USING (
+  EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND role = 'admin')
+);

--- a/supabase/migrations/20260511010000_cleanup_dead_tables_and_dup_profile.sql
+++ b/supabase/migrations/20260511010000_cleanup_dead_tables_and_dup_profile.sql
@@ -1,0 +1,17 @@
+-- DB cleanup 2026-05-11:
+-- 1) Drop 5 dead empty tables (zero rows, zero code refs)
+-- 2) Resolve duplicate profile (maimoona.ansari@gmail.com orphan admin row)
+-- 3) Add unique index on profiles.email to prevent future dups
+
+DROP TABLE IF EXISTS public.analytics_alerts CASCADE;
+DROP TABLE IF EXISTS public.analytics_summary CASCADE;
+DROP TABLE IF EXISTS public.class_metrics_summary CASCADE;
+DROP TABLE IF EXISTS public.student_metrics_summary CASCADE;
+DROP TABLE IF EXISTS public.role_permissions CASCADE;
+
+DELETE FROM public.profiles
+WHERE id = '794ca656-d5c8-4c28-bb36-e6f58baaa34e'
+  AND email = 'maimoona.ansari@gmail.com'
+  AND role = 'admin';
+
+CREATE UNIQUE INDEX IF NOT EXISTS profiles_email_unique_idx ON public.profiles (LOWER(email));

--- a/supabase/migrations/20260511020000_enable_rls_unprotected_tables.sql
+++ b/supabase/migrations/20260511020000_enable_rls_unprotected_tables.sql
@@ -1,0 +1,36 @@
+-- DB cleanup 2026-05-11: enable RLS on 4 tables previously exposed to anon role.
+-- Policies: admin-only RW (+ teacher SELECT for attendance-related tables).
+-- service_role bypasses RLS, so edge functions inserting into email_logs / aan still work.
+
+ALTER TABLE public.app_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.email_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.attendance_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.attendance_absence_notifications ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "app_settings_admin_all" ON public.app_settings
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "email_logs_admin_select" ON public.email_logs
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "attendance_settings_admin_all" ON public.attendance_settings
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+CREATE POLICY "attendance_settings_teacher_select" ON public.attendance_settings
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role IN ('teacher','admin'))
+  );
+
+CREATE POLICY "aan_admin_all" ON public.attendance_absence_notifications
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+CREATE POLICY "aan_teacher_select" ON public.attendance_absence_notifications
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role IN ('teacher','admin'))
+  );


### PR DESCRIPTION
## Summary

Three multi-session shipments rolled into one PR:

### Phase 3 — School Operations
- **3.1 Parent-Teacher Interview Scheduling** — 3-table system (windows/slots/bookings), `/admin/interviews` admin panel, `/parent/interviews` booking page, `send-interview-confirmation` edge function (deployed live)
- **3.3 Bulk Attendance CSV Export** — date range + section filter on `/admin/reports`, new "Full Attendance Log" report

### DB Cleanup
- Dropped 5 dead empty tables (`analytics_alerts`, `analytics_summary`, `class_metrics_summary`, `student_metrics_summary`, `role_permissions`)
- Resolved orphan duplicate profile (`maimoona.ansari@gmail.com`)
- `LOWER(email)` UNIQUE index on `profiles` to prevent future dups
- RLS + admin-only policies on 4 previously-exposed tables (`app_settings`, `email_logs`, `attendance_settings`, `attendance_absence_notifications`)
- ANALYZE refreshed stale planner stats
- 28 base tables now (was 33), 0 dups, 0 RLS gaps

### Admin UX Consolidation
- Sidebar 16 → 11 items via new `/admin/panel` tabbed hub (Bulk Import / Templates / Activity Log / Interviews / Schedules / Absences)
- Old URLs auto-redirect to corresponding `?tab=` deep links
- Admin Dashboard cleaned: hardcoded fake weekly bars → real query, fake 74% donut fallback → "—", fake "Remind Teachers" button removed, broken `?tab=performance` links repointed, redundant Quick Nav grid deleted, welcome banner duplicate buttons collapsed

## Build

`npm run build` exit 0, 5.02s, no new warnings vs baseline.

## Test plan

- [ ] Log in as admin → sidebar shows 11 items, "Admin Panel" entry visible
- [ ] Click Admin Panel → 6 tabs render
- [ ] Visit `/admin/panel?tab=interviews` directly → opens Interviews tab
- [ ] Visit old `/admin/communication-templates` → redirects to `/admin/panel?tab=templates`
- [ ] Dashboard: no 74% fake donut when real data is 0, no Quick Nav grid
- [ ] Log in as parent → Interviews entry in parent sidebar → book a slot → email arrives in Resend dashboard
- [ ] Reports page → set date range → CSV downloads only rows in range

## Migrations applied live

- `20260511000000_create_interview_tables.sql`
- `20260511010000_cleanup_dead_tables_and_dup_profile.sql`
- `20260511020000_enable_rls_unprotected_tables.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)